### PR TITLE
Update Python version to 3.13

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,7 +5,7 @@
   "project_description": "A brief description of the project.",
   "author_name": "Your Name",
   "author_email": "you@example.com",
-  "python_version": "3.11",
+  "python_version": "3.13",
   "python_package_name": "{{cookiecutter.project_slug.lower().replace(' ', '_').replace('-', '_')}}",
   "db_type": ["POSTGRESQL", "SQLITE"],
   "db_name": "app_db",

--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile
 
 # --- Стадия сборки зависимостей ---
-FROM python:{{cookiecutter.python_version}}-slim AS builder
+FROM python:3.13-slim AS builder
 
 LABEL stage="builder"
 
@@ -39,7 +39,7 @@ RUN uv sync --frozen
 # Добавил --frozen-lockfile для uv sync, чтобы он падал, если lock не соответствует toml.
 
 # --- Финальная стадия ---
-FROM python:{{cookiecutter.python_version}}-slim AS runner
+FROM python:3.13-slim AS runner
 
 LABEL stage="runner"
 
@@ -50,7 +50,7 @@ ENV PYTHONUNBUFFERED=1 \
     # Путь к файлу БД SQLite внутри контейнера (если используется)
     # Может быть переопределен через DB_SQLITE_FILE в .env
     APP_SQLITE_DB_PATH="/app/data/db/main.sqlite" \
-    PYTHONPATH="/app/src:/opt/venv/lib/python{{cookiecutter.python_version}}/site-packages:$PYTHONPATH"
+    PYTHONPATH="/app/src:/opt/venv/lib/python3.13/site-packages:$PYTHONPATH"
 
 # Создаем группу и пользователя приложения
 RUN groupadd -r appgroup && useradd -r -g appgroup -d /app -s /sbin/nologin -c "Application User" appuser

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -4,7 +4,7 @@ name = "{{cookiecutter.python_package_name}}"
 version = "0.1.0"
 description = "{{cookiecutter.project_description}}"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.115.12",
     "loguru>=0.7.3",
@@ -173,7 +173,7 @@ skip-magic-trailing-comma = true # Убирать магическую запя�
 # --- pyright ---
 [tool.pyright]
 # 🔹 Основные настройки
-pythonVersion = "3.10" # Версия Python, для которой проверяется код
+pythonVersion = "3.13" # Версия Python, для которой проверяется код
 pythonPlatform = "Linux" # Платформа: "Linux", "Windows" или "Darwin" (macOS)
 typeCheckingMode = "strict" # Режим проверки типов: "off", "basic", "strict"
 


### PR DESCRIPTION
## Summary
- set `python_version` to 3.13 in cookiecutter.json
- switch Dockerfile base images to Python 3.13
- require Python 3.13 in the template's pyproject

## Testing
- `nox -s ci-3.12 ci-3.13` *(fails: command not found)*
- `pytest -q` *(fails: SyntaxError in template tests)*

------
https://chatgpt.com/codex/tasks/task_e_687375cf06308330b4b8ba0d3fe30836