### PR TITLE
Add tasks endpoint with Redis

### DIFF
--- a/{{cookiecutter.project_slug}}/src/api/main.py
+++ b/{{cookiecutter.project_slug}}/src/api/main.py
@@ -2,8 +2,10 @@ from starlette.applications import Starlette
 from starlette.routing import Router
 
 from .health import router as health_router
+from .tasks import router as tasks_router
 
 router = Router()
 router.routes.extend(health_router.routes)
+router.routes.extend(tasks_router.routes)
 
 app = Starlette(routes=router.routes)

--- a/{{cookiecutter.project_slug}}/src/api/tasks.py
+++ b/{{cookiecutter.project_slug}}/src/api/tasks.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+from typing import Any, Dict
+
+from pydantic import BaseModel, Field, ValidationError
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route, Router
+from starlette.status import HTTP_202_ACCEPTED, HTTP_400_BAD_REQUEST
+
+from ..utils import redis_stream, TASKS_STREAM_NAME
+
+router = Router()
+
+
+class TaskPayload(BaseModel):
+    data: Any
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+async def create_task(request: Request) -> JSONResponse:
+    try:
+        payload = TaskPayload(**await request.json())
+    except ValidationError as exc:  # pragma: no cover - Pydantic ensures detail
+        return JSONResponse({"detail": exc.errors()}, status_code=HTTP_400_BAD_REQUEST)
+
+    message = {
+        "task_id": str(uuid4()),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "payload": payload.model_dump(),
+        "trace_context": {"trace_id": "", "span_id": ""},
+    }
+    await redis_stream.xadd(TASKS_STREAM_NAME, message)
+    return JSONResponse({"status": "accepted"}, status_code=HTTP_202_ACCEPTED)
+
+
+router.routes.append(Route("/tasks", create_task, methods=["POST"]))

--- a/{{cookiecutter.project_slug}}/src/utils/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/utils/__init__.py
@@ -1,3 +1,5 @@
-# Utility package
-# Add general-purpose helper functions and utilities here.
-# Group related utilities into submodules if necessary.
+"""Utility helpers for the application."""
+
+from .redis_stream import redis_stream, TASKS_STREAM_NAME, FakeRedisStream
+
+__all__ = ["redis_stream", "TASKS_STREAM_NAME", "FakeRedisStream"]

--- a/{{cookiecutter.project_slug}}/src/utils/redis_stream.py
+++ b/{{cookiecutter.project_slug}}/src/utils/redis_stream.py
@@ -1,0 +1,21 @@
+from collections import defaultdict
+from typing import Any, Dict, List, DefaultDict
+
+
+class FakeRedisStream:
+    """In-memory Redis Streams emulator."""
+
+    def __init__(self) -> None:
+        self.streams: DefaultDict[str, List[Dict[str, Any]]] = defaultdict(list)
+
+    async def xadd(self, stream_name: str, fields: Dict[str, Any]) -> str:
+        """Add a message to the specified stream."""
+        self.streams[stream_name].append(fields)
+        return str(len(self.streams[stream_name]))
+
+
+TASKS_STREAM_NAME = "tasks:stream"
+
+redis_stream = FakeRedisStream()
+
+__all__ = ["redis_stream", "TASKS_STREAM_NAME", "FakeRedisStream"]

--- a/{{cookiecutter.project_slug}}/tests/integration/test_api_tasks.py
+++ b/{{cookiecutter.project_slug}}/tests/integration/test_api_tasks.py
@@ -1,0 +1,20 @@
+import pytest
+from httpx import AsyncClient
+from starlette import status
+
+from {{cookiecutter.python_package_name}}.utils import redis_stream, TASKS_STREAM_NAME
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_should_return_202_and_store_message(async_client: AsyncClient):
+    redis_stream.streams.clear()
+    payload = {"data": "hello", "metadata": {"foo": "bar"}}
+
+    response = await async_client.post("/tasks", json=payload)
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert TASKS_STREAM_NAME in redis_stream.streams
+    assert redis_stream.streams[TASKS_STREAM_NAME]
+    message = redis_stream.streams[TASKS_STREAM_NAME][-1]
+    assert message["payload"] == payload


### PR DESCRIPTION
## Summary
- add tasks POST endpoint
- push messages to in-memory Redis Streams
- expose redis stream util
- integration test for tasks endpoint

## Testing
- `pytest -q` *(fails: invalid syntax due to Jinja placeholders)*
- `nox -s ci-3.12 ci-3.13` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68737b476f4483308ce2877b8aa67ac5