### PR TITLE
Update Docker setup

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -47,9 +47,6 @@ LABEL stage="runner"
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PATH="/opt/venv/bin:$PATH" \
-    # Путь к файлу БД SQLite внутри контейнера (если используется)
-    # Может быть переопределен через DB_SQLITE_FILE в .env
-    APP_SQLITE_DB_PATH="/app/data/db/main.sqlite" \
     PYTHONPATH="/app/src:/opt/venv/lib/python3.13/site-packages:$PYTHONPATH"
 
 # Создаем группу и пользователя приложения
@@ -64,10 +61,6 @@ COPY --from=builder --chown=appuser:appgroup /app/.venv /opt/venv
 # Копируем исходный код приложения
 # Убедимся, что .dockerignore настроен правильно, чтобы не копировать лишнее
 COPY --chown=appuser:appgroup ./src ./src
-
-# Создаем директорию для данных, если SQLite будет использоваться внутри контейнера
-# и устанавливаем права (пример)
-RUN mkdir -p /app/data/db && chown -R appuser:appgroup /app/data
 
 # Устанавливаем пользователя приложения
 USER appuser

--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -1,6 +1,4 @@
-# docker-compose.yml
 version: '3.9'
-
 services:
   app:
     build:
@@ -10,10 +8,39 @@ services:
       - "${APP_PORT:-{{cookiecutter.app_port_host}}}:{{cookiecutter.internal_app_port}}"
     env_file:
       - .env
-    environment:
-      # Дополнительные переменные окружения, если нужны
     volumes:
       - ./src:/app/src
+    depends_on:
+      - redis
+      - statsd
+      - jaeger
+      - loki
+    networks:
+      - app_network
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    networks:
+      - app_network
+  statsd:
+    image: prom/statsd-exporter:latest
+    ports:
+      - "8125:8125/udp"
+    networks:
+      - app_network
+  jaeger:
+    image: jaegertracing/all-in-one:1.55
+    ports:
+      - "16686:16686"
+      - "14268:14268"
+    networks:
+      - app_network
+  loki:
+    image: grafana/loki:2.9.4
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
     networks:
       - app_network
 


### PR DESCRIPTION
## Summary
- update Dockerfile to Python 3.13 and remove SQLite parts
- redefine docker-compose to run redis, statsd, jaeger and loki

## Testing
- `pytest -q` *(fails: No module named pytest)*
- `nox -s ci-3.12 ci-3.13` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68737ed989c083309e4270ee00a061d8