### PR TITLE
Increase coverage threshold and extend tests

### DIFF
--- a/{{cookiecutter.project_slug}}/noxfile.py
+++ b/{{cookiecutter.project_slug}}/noxfile.py
@@ -39,7 +39,7 @@ SRC_DIR: str = "src"
 TESTS_DIR: str = "tests"
 DOCS_DIR: str = "docs"
 COVERAGE_FAIL_UNDER: int = (
-    40  # Минимальный процент покрытия для тестов ( временно снижено с 70 )
+    80  # Минимальный процент покрытия для тестов
 )
 os.environ["PYTHONDONTWRITEBYTECODE"] = "1"
 

--- a/{{cookiecutter.project_slug}}/tests/integration/test_api_health.py
+++ b/{{cookiecutter.project_slug}}/tests/integration/test_api_health.py
@@ -2,11 +2,16 @@ import pytest
 from httpx import AsyncClient
 from starlette import status
 
+from {{cookiecutter.python_package_name}}.utils import statsd_client, tracer
+
 pytestmark = pytest.mark.asyncio
 
 
 async def test_health_check(async_client: AsyncClient):
     """Tests the /health endpoint."""
+    statsd_client.reset()
+    tracer.spans.clear()
+
     response = await async_client.get("/health")
 
     assert response.status_code == status.HTTP_200_OK
@@ -16,3 +21,5 @@ async def test_health_check(async_client: AsyncClient):
     assert isinstance(data["timestamp"], str)
     assert isinstance(data["redis_connected"], bool)
     assert isinstance(data["version"], str) and data["version"]
+    assert statsd_client.counters["requests.health"] == 1
+    assert tracer.spans and tracer.spans[-1].name == "health_check"

--- a/{{cookiecutter.project_slug}}/tests/integration/test_api_tasks.py
+++ b/{{cookiecutter.project_slug}}/tests/integration/test_api_tasks.py
@@ -6,6 +6,7 @@ from {{cookiecutter.python_package_name}}.utils import (
     redis_stream,
     TASKS_STREAM_NAME,
     statsd_client,
+    tracer,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -14,6 +15,7 @@ pytestmark = pytest.mark.asyncio
 async def test_should_return_202_and_store_message(async_client: AsyncClient):
     redis_stream.streams.clear()
     statsd_client.reset()
+    tracer.spans.clear()
     payload = {"data": "hello", "metadata": {"foo": "bar"}}
 
     response = await async_client.post("/tasks", json=payload)
@@ -24,3 +26,10 @@ async def test_should_return_202_and_store_message(async_client: AsyncClient):
     message = redis_stream.streams[TASKS_STREAM_NAME][-1]
     assert message["payload"] == payload
     assert statsd_client.counters["requests.tasks"] == 1
+    assert tracer.spans and tracer.spans[-1].name == "create_task"
+
+
+async def test_should_return_400_when_payload_invalid(async_client: AsyncClient):
+    response = await async_client.post("/tasks", json={"foo": "bar"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/{{cookiecutter.project_slug}}/tests/unit/test_config.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_config.py
@@ -8,6 +8,12 @@ def test_log_settings_instantiation():
     assert log_settings.console_level == "INFO"
 
 
+def test_log_settings_env_override(monkeypatch):
+    monkeypatch.setenv("LOG_CONSOLE_LEVEL", "WARNING")
+    log_settings = LogSettings()
+    assert log_settings.console_level == "WARNING"
+
+
 
 
 def test_app_settings_instantiation(monkeypatch):
@@ -17,6 +23,12 @@ def test_app_settings_instantiation(monkeypatch):
     assert app_settings.app_env == "test"
     assert app_settings.log is not None
     assert app_settings.app_host == "0.0.0.0"
+
+
+def test_app_settings_port_env(monkeypatch):
+    monkeypatch.setenv("APP_APP_PORT", "1234")
+    settings_override = AppSettings()
+    assert settings_override.app_port == 1234
 
 
 def test_data_dir_creation():


### PR DESCRIPTION
## Summary
- ensure coverage threshold is set to 80% in the template `noxfile.py`
- extend task endpoint tests with tracer and validation checks
- extend health endpoint tests with tracer and metrics checks
- cover environment variable overrides in configuration tests

## Testing
- `python3 -m pytest -q tests/unit/test_config.py::test_log_settings_instantiation` *(fails: No module named pytest)*
- `nox -s ci-3.12 ci-3.13` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873800c1ef4833083f6737cbadd8645