### PR TITLE
Remove unused DB options

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,12 +7,6 @@
   "author_email": "you@example.com",
   "python_version": "3.13",
   "python_package_name": "{{cookiecutter.project_slug.lower().replace(' ', '_').replace('-', '_')}}",
-  "db_type": ["POSTGRESQL", "SQLITE"],
-  "db_name": "app_db",
-  "db_user": "app_user",
-  "db_password": "changeme",
-  "db_host": "db",
-  "db_port": "5432",
   "app_port_host": "8000",
   "internal_app_port": "8000",
   "docker_image_name": "{{cookiecutter.project_slug}}",
@@ -20,7 +14,6 @@
   "repo_name": "{{cookiecutter.project_slug}}",
   "copyright_year": "2024",
   "log_directory": "logs",
-  "sqlite_db_path": "data/db/main.sqlite",
   "_copy_without_render": [
     "*.html",
     "docs/_static/*"

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,35 +1,16 @@
-import os
-import pathlib
-import sys
+"""Hook executed before project generation."""
 
-PROJECT_DIRECTORY = pathlib.Path.cwd()
+from __future__ import annotations
 
-def main():
-    db_type = "{{ cookiecutter.db_type }}"
-    sqlite_db_path_str = "{{ cookiecutter.sqlite_db_path }}"
+from pathlib import Path
 
-    if db_type == "SQLITE":
-        if not sqlite_db_path_str:
-            print("ERROR: sqlite_db_path is not set but db_type is SQLITE.")
-            sys.exit(1)
 
-        # project_slug is the name of the directory cookiecutter creates for the project
-        project_slug = "{{ cookiecutter.project_slug }}"
+PROJECT_DIRECTORY = Path.cwd()
 
-        # The script runs from within the root of the new project directory
-        # So, PROJECT_DIRECTORY is already {{cookiecutter.project_slug}}
-        # Therefore, we can resolve sqlite_db_path_str directly
-        sqlite_file_path = pathlib.Path(sqlite_db_path_str)
 
-        try:
-            # Create parent directories
-            sqlite_file_path.parent.mkdir(parents=True, exist_ok=True)
-            # Create the file
-            sqlite_file_path.touch(exist_ok=True) # exist_ok=True in case it was somehow created
-            print(f"SUCCESS: Ensured SQLite file and directories exist at {sqlite_file_path}")
-        except Exception as e:
-            print(f"ERROR: Could not create SQLite file or directories: {e}")
-            sys.exit(1)
+def main() -> None:
+    """Placeholder pre-generation logic."""
+    pass
 
 if __name__ == "__main__":
     main()

--- a/{{cookiecutter.project_slug}}/src/models/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/models/__init__.py
@@ -1,3 +1,2 @@
 # Models package
-# All data models should inherit from Base in name.db.base
-# Ensure models are imported here or in alembic/env.py for Alembic discovery.
+# Import application models here for discovery by tooling.


### PR DESCRIPTION
## Summary
- clean up old DB config fields in cookiecutter.json
- strip database logic from pre-gen hook
- simplify comment in models package

## Testing
- `pytest -q` *(fails: SyntaxError from cookiecutter placeholders)*
- `nox -s ci-3.12 ci-3.13` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873a165c72483308119cdd51a2da983