### PR TITLE
Add Redis ping in health check

### DIFF
--- a/{{cookiecutter.project_slug}}/src/api/health.py
+++ b/{{cookiecutter.project_slug}}/src/api/health.py
@@ -2,9 +2,11 @@ from datetime import datetime, timezone
 
 from starlette.responses import JSONResponse
 from starlette.routing import Route, Router
+from starlette.status import HTTP_200_OK, HTTP_503_SERVICE_UNAVAILABLE
 
 from ..utils.metrics import statsd_client
 from ..utils.tracing import tracer
+from ..utils import redis_stream
 
 from .. import __version__
 
@@ -16,12 +18,20 @@ async def health_check(request):
     with tracer.start_as_current_span("health_check"):
         await statsd_client.incr("requests.health")
 
+        try:
+            await redis_stream.ping()
+            redis_ok = True
+        except Exception:  # pragma: no cover - redis ping failures
+            redis_ok = False
+
         payload = {
-            "status": "healthy",
+            "status": "healthy" if redis_ok else "unhealthy",
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "redis_connected": True,
+            "redis_connected": redis_ok,
             "version": __version__,
         }
-        return JSONResponse(payload)
+        status_code = HTTP_200_OK if redis_ok else HTTP_503_SERVICE_UNAVAILABLE
+        return JSONResponse(payload, status_code=status_code)
+
 
 router.routes.append(Route("/health", health_check, methods=["GET"]))

--- a/{{cookiecutter.project_slug}}/src/utils/redis_stream.py
+++ b/{{cookiecutter.project_slug}}/src/utils/redis_stream.py
@@ -16,6 +16,10 @@ class RedisStream:
             stream_name, fields, maxlen=settings.redis.max_length
         )
 
+    async def ping(self) -> bool:
+        """Check if Redis connection is alive."""
+        return await self.redis.ping()
+
 
 TASKS_STREAM_NAME = settings.redis.stream_name
 

--- a/{{cookiecutter.project_slug}}/tests/conftest.py
+++ b/{{cookiecutter.project_slug}}/tests/conftest.py
@@ -22,6 +22,9 @@ class FakeRedis:
         self.streams[stream_name].append(fields)
         return str(len(self.streams[stream_name]))
 
+    async def ping(self) -> bool:
+        return True
+
 
 @pytest_asyncio.fixture(autouse=True)
 async def fake_redis(monkeypatch) -> AsyncGenerator[FakeRedis, None]:

--- a/{{cookiecutter.project_slug}}/tests/integration/test_api_health.py
+++ b/{{cookiecutter.project_slug}}/tests/integration/test_api_health.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.asyncio
 
 
 async def test_health_check(async_client: AsyncClient):
-    """Tests the /health endpoint."""
+    """Tests the /health endpoint when Redis is reachable."""
     statsd_client.reset()
     tracer.spans.clear()
 
@@ -20,6 +20,29 @@ async def test_health_check(async_client: AsyncClient):
     assert data["status"] == "healthy"
     assert isinstance(data["timestamp"], str)
     assert isinstance(data["redis_connected"], bool)
+    assert isinstance(data["version"], str) and data["version"]
+    assert statsd_client.counters["requests.health"] == 1
+    assert tracer.spans and tracer.spans[-1].name == "health_check"
+
+
+async def test_should_return_503_when_redis_unavailable(
+    async_client: AsyncClient, fake_redis, monkeypatch
+):
+    """Returns 503 when Redis ping fails."""
+    async def fail_ping() -> bool:
+        raise ConnectionError("redis down")
+
+    monkeypatch.setattr(fake_redis, "ping", fail_ping)
+    statsd_client.reset()
+    tracer.spans.clear()
+
+    response = await async_client.get("/health")
+
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    data = response.json()
+    assert data["status"] == "unhealthy"
+    assert data["redis_connected"] is False
+    assert isinstance(data["timestamp"], str)
     assert isinstance(data["version"], str) and data["version"]
     assert statsd_client.counters["requests.health"] == 1
     assert tracer.spans and tracer.spans[-1].name == "health_check"


### PR DESCRIPTION
## Summary
- check Redis connectivity in `health_check`
- support ping in RedisStream
- update FakeRedis fixture
- simulate Redis failure in integration tests

## Testing
- `ruff format src`
- `pytest -q` *(fails: invalid placeholders in template)*
- `nox -s ci-3.12 ci-3.13` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873b186b3208330b79c203e78bca78b