### PR TITLE
Add graceful shutdown hooks

### DIFF
--- a/{{cookiecutter.project_slug}}/src/api/main.py
+++ b/{{cookiecutter.project_slug}}/src/api/main.py
@@ -1,6 +1,10 @@
 from starlette.applications import Starlette
 from starlette.routing import Router
 
+from ..core.logging_config import get_logger
+from ..utils import statsd_client, tracer
+from . import health, tasks
+
 from .health import router as health_router
 from .tasks import router as tasks_router
 
@@ -8,4 +12,36 @@ router = Router()
 router.routes.extend(health_router.routes)
 router.routes.extend(tasks_router.routes)
 
+log = get_logger(__name__)
+
 app = Starlette(routes=router.routes)
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    log.info("Application startup")
+
+
+@app.on_event("shutdown")
+async def on_shutdown() -> None:
+    await _close_repo(health.redis_repo)
+    await _close_repo(tasks.tasks_service.repo)
+    statsd_client.reset()
+    tracer.spans.clear()
+    log.info("Application shutdown complete")
+
+
+async def _close_repo(repo) -> None:
+    redis_obj = getattr(repo, "redis", repo)
+    close = getattr(redis_obj, "close", None)
+    if close:
+        try:
+            await close()
+        except Exception:
+            pass
+    wait_closed = getattr(redis_obj, "wait_closed", None)
+    if wait_closed:
+        try:
+            await wait_closed()
+        except Exception:
+            pass

--- a/{{cookiecutter.project_slug}}/tests/integration/test_shutdown.py
+++ b/{{cookiecutter.project_slug}}/tests/integration/test_shutdown.py
@@ -1,0 +1,36 @@
+import pytest
+
+from {{cookiecutter.python_package_name}}.api import app, health, tasks
+from {{cookiecutter.python_package_name}}.utils import statsd_client, tracer
+from tests.conftest import FakeRedis
+
+
+class FakeRedisWithClose(FakeRedis):
+    def __init__(self) -> None:
+        super().__init__()
+        self.closed = False
+        self.waited = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        self.waited = True
+
+
+@pytest.mark.asyncio
+async def test_should_flush_and_close_on_shutdown(monkeypatch) -> None:
+    fake = FakeRedisWithClose()
+    monkeypatch.setattr(health, "redis_repo", fake)
+    monkeypatch.setattr(tasks.tasks_service, "repo", fake)
+
+    await statsd_client.incr("test")
+    with tracer.start_as_current_span("span"):
+        pass
+
+    await app.router.startup()
+    await app.router.shutdown()
+
+    assert fake.closed and fake.waited
+    assert statsd_client.counters == {}
+    assert tracer.spans == []


### PR DESCRIPTION
## Summary
- register startup and shutdown events
- close Redis and flush metrics/traces on shutdown
- add integration test for shutdown behaviour

## Testing
- `python3 -m pytest -q` *(fails: SyntaxError in tests because cookiecutter variables are unresolved)*
- `nox -s ci-3.12 ci-3.13` *(fails: `nox` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6873b58e478c8330a0046dc28e13951a