### PR TITLE
Add circuit breaker to Redis repository

### DIFF
--- a/{{cookiecutter.project_slug}}/src/core/config.py
+++ b/{{cookiecutter.project_slug}}/src/core/config.py
@@ -49,6 +49,8 @@ class RedisSettings(BaseSettings):
     consumer_name: str = f"{os.getenv('HOSTNAME', 'local')}:{os.getpid()}"
     max_length: int = 100_000
     retention_ms: int = 3_600_000
+    breaker_fail_max: int = 3
+    breaker_reset_timeout: int = 30
 
 
 class StatsDSettings(BaseSettings):

--- a/{{cookiecutter.project_slug}}/src/repository/redis_repo.py
+++ b/{{cookiecutter.project_slug}}/src/repository/redis_repo.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import Any, Dict, Optional
+
+import aiobreaker
 
 from redis.asyncio import Redis
 
@@ -10,18 +13,24 @@ from ..core.config import settings
 class RedisRepository:
     """Wrapper around Redis operations used by the service."""
 
-    def __init__(self, client: Optional[Redis] = None, url: str = settings.redis.url) -> None:
+    def __init__(
+        self, client: Optional[Redis] = None, url: str = settings.redis.url
+    ) -> None:
         self.redis = client or Redis.from_url(url, decode_responses=True)
+        self.breaker = aiobreaker.CircuitBreaker(
+            fail_max=settings.redis.breaker_fail_max,
+            timeout_duration=timedelta(seconds=settings.redis.breaker_reset_timeout),
+        )
 
     async def add_to_stream(self, stream_name: str, message: Dict[str, Any]) -> str:
         """Add a message to a Redis Stream."""
-        return await self.redis.xadd(
-            stream_name, message, maxlen=settings.redis.max_length
+        return await self.breaker.call_async(
+            self.redis.xadd, stream_name, message, maxlen=settings.redis.max_length
         )
 
     async def ping(self) -> bool:
         """Check Redis connectivity."""
-        return await self.redis.ping()
+        return await self.breaker.call_async(self.redis.ping)
 
 
 __all__ = ["RedisRepository"]

--- a/{{cookiecutter.project_slug}}/tests/unit/test_redis_repo.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_redis_repo.py
@@ -1,6 +1,10 @@
 import pytest
 
-from {{cookiecutter.python_package_name}}.repository.redis_repo import RedisRepository
+import aiobreaker
+
+from {{cookiecutter.python_package_name}}.repository.redis_repo import (
+    RedisRepository,
+)
 from tests.conftest import FakeRedis
 
 
@@ -14,3 +18,29 @@ async def test_should_add_to_stream_and_ping() -> None:
     assert "mystream" in fake.streams
     assert fake.streams["mystream"][0]["foo"] == "bar"
     assert await repo.ping()
+
+
+@pytest.mark.asyncio
+async def test_should_open_breaker_after_failures() -> None:
+    class FailingRedis(FakeRedis):
+        def __init__(self, fail_times: int) -> None:
+            super().__init__()
+            self.fail_times = fail_times
+            self.calls = 0
+
+        async def xadd(self, stream_name: str, fields: dict) -> str:
+            self.calls += 1
+            if self.calls <= self.fail_times:
+                raise ConnectionError("redis down")
+            return await super().xadd(stream_name, fields)
+
+    repo = RedisRepository(client=FailingRedis(fail_times=2))
+
+    # first two calls fail but do not raise CircuitBreakerError
+    for _ in range(2):
+        with pytest.raises(ConnectionError):
+            await repo.add_to_stream("s", {"foo": "bar"})
+
+    # third call should trip the breaker
+    with pytest.raises(aiobreaker.CircuitBreakerError):
+        await repo.add_to_stream("s", {"foo": "bar"})


### PR DESCRIPTION
## Summary
- integrate `aiobreaker` circuit breaker into RedisRepository
- expose breaker thresholds via settings
- test breaker tripping after multiple failures

## Testing
- `pytest -q` *(fails: SyntaxError in template placeholders)*
- `nox -s ci-3.12 --no-error-on-missing-interpreters` *(fails: project placeholders invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6873b6c545dc833085e0ad0125f75773