### PR TITLE
Add request size limit and sanitize task payload

### DIFF
--- a/{{cookiecutter.project_slug}}/src/api/tasks.py
+++ b/{{cookiecutter.project_slug}}/src/api/tasks.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import json
+from html import escape
 from typing import Any, Dict
 
 from pydantic import BaseModel, Field, ValidationError
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route, Router
-from starlette.status import HTTP_202_ACCEPTED, HTTP_400_BAD_REQUEST
+from starlette.status import (
+    HTTP_202_ACCEPTED,
+    HTTP_400_BAD_REQUEST,
+    HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+)
 
 from .deps import get_tasks_service
 from ..services.tasks_service import TasksService
@@ -15,6 +21,19 @@ from ..utils.tracing import tracer
 
 
 tasks_service: TasksService = get_tasks_service()
+
+
+MAX_BODY_SIZE = 1_048_576
+
+
+def _sanitize(value: Any) -> Any:
+    if isinstance(value, str):
+        return escape(value)
+    if isinstance(value, list):
+        return [_sanitize(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _sanitize(v) for k, v in value.items()}
+    return value
 
 
 class TaskPayload(BaseModel):
@@ -28,10 +47,24 @@ def get_router(service: TasksService | None = None) -> Router:
 
     async def create_task(request: Request) -> JSONResponse:
         with tracer.start_as_current_span("create_task"):
+            body = await request.body()
+            if len(body) > MAX_BODY_SIZE:
+                return JSONResponse(
+                    {"detail": "Payload too large"},
+                    status_code=HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                )
             try:
-                payload = TaskPayload(**await request.json())
+                raw = json.loads(body.decode())
+                sanitized = _sanitize(raw)
+                payload = TaskPayload(**sanitized)
+            except json.JSONDecodeError:
+                return JSONResponse(
+                    {"detail": "Invalid JSON"}, status_code=HTTP_400_BAD_REQUEST
+                )
             except ValidationError as exc:  # pragma: no cover - Pydantic ensures detail
-                return JSONResponse({"detail": exc.errors()}, status_code=HTTP_400_BAD_REQUEST)
+                return JSONResponse(
+                    {"detail": exc.errors()}, status_code=HTTP_400_BAD_REQUEST
+                )
 
             await service.enqueue_task(payload.model_dump())
             await statsd_client.incr("requests.tasks")
@@ -43,4 +76,4 @@ def get_router(service: TasksService | None = None) -> Router:
 
 router = get_router()
 
-__all__ = ["router", "get_router", "tasks_service", "TaskPayload"]
+__all__ = ["TaskPayload", "get_router", "router", "tasks_service"]

--- a/{{cookiecutter.project_slug}}/tests/integration/test_api_tasks.py
+++ b/{{cookiecutter.project_slug}}/tests/integration/test_api_tasks.py
@@ -32,3 +32,13 @@ async def test_should_return_400_when_payload_invalid(async_client: AsyncClient)
     response = await async_client.post("/tasks", json={"foo": "bar"})
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+async def test_should_return_413_when_payload_too_large(async_client: AsyncClient):
+    big_data = "x" * (1024 * 1024 + 1)
+    response = await async_client.post(
+        "/tasks",
+        json={"data": big_data, "metadata": {}},
+    )
+
+    assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE


### PR DESCRIPTION
## Summary
- limit body size to 1MB before parsing in tasks API
- escape strings in TaskPayload
- test 413 response when payload too large

## Testing
- `PYENV_VERSION=3.13.3 PYTHONPATH=src pytest -q` *(fails: invalid syntax from template placeholders)*
- `PYENV_VERSION=3.13.3 nox -s ci-3.13` *(fails: installing deps due to template placeholders)*
- `PYENV_VERSION=3.13.3 nox -s ci-3.12` *(fails: installing deps due to template placeholders)*

------
https://chatgpt.com/codex/tasks/task_e_6873b8e1c15883309a14e1e1adb7f15b