### PR TITLE
Add resource metrics reporting

### DIFF
--- a/{{cookiecutter.project_slug}}/src/services/tasks_service.py
+++ b/{{cookiecutter.project_slug}}/src/services/tasks_service.py
@@ -1,18 +1,35 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any, Dict, List, Tuple
 from uuid import uuid4
 
+import psutil
+
+try:
+    import GPUtil  # type: ignore
+    GPU_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    GPU_AVAILABLE = False
+
 from ..repository.redis_repo import RedisRepository
-from ..utils import TASKS_STREAM_NAME
+from ..utils import TASKS_STREAM_NAME, statsd_client
 
 
 class TasksService:
-    """Service handling task enqueueing."""
+    """Service handling task enqueueing and metrics reporting."""
 
     def __init__(self, repo: RedisRepository) -> None:
         self.repo = repo
+        self.cpu_samples: List[float] = []
+        self.mem_samples: List[float] = []
+        self.gpu_load_samples: List[float] = []
+        self.gpu_mem_samples: List[float] = []
+
+    @staticmethod
+    def _calculate_metrics(values: List[float]) -> Tuple[float, float, float]:
+        avg = sum(values) / len(values)
+        return avg, min(values), max(values)
 
     async def enqueue_task(self, payload: Dict[str, Any]) -> str:
         """Serialize and enqueue a task payload."""
@@ -22,7 +39,47 @@ class TasksService:
             "payload": payload,
             "trace_context": {"trace_id": "", "span_id": ""},
         }
-        return await self.repo.add_to_stream(TASKS_STREAM_NAME, message)
+        result = await self.repo.add_to_stream(TASKS_STREAM_NAME, message)
+        await self._record_usage()
+        return result
+
+    async def _record_usage(self) -> None:
+        cpu = psutil.cpu_percent()
+        mem = psutil.virtual_memory().percent
+        self.cpu_samples.append(cpu)
+        self.mem_samples.append(mem)
+
+        cpu_avg, cpu_min, cpu_max = self._calculate_metrics(self.cpu_samples)
+        mem_avg, mem_min, mem_max = self._calculate_metrics(self.mem_samples)
+
+        await statsd_client.gauge("cpu.avg", cpu_avg)
+        await statsd_client.gauge("cpu.min", cpu_min)
+        await statsd_client.gauge("cpu.max", cpu_max)
+        await statsd_client.gauge("mem.avg", mem_avg)
+        await statsd_client.gauge("mem.min", mem_min)
+        await statsd_client.gauge("mem.max", mem_max)
+
+        if GPU_AVAILABLE:
+            gpus = GPUtil.getGPUs()
+            if gpus:
+                loads = [g.load * 100 for g in gpus]
+                mems = [g.memoryUtil * 100 for g in gpus]
+                avg_load = sum(loads) / len(loads)
+                avg_mem = sum(mems) / len(mems)
+                self.gpu_load_samples.append(avg_load)
+                self.gpu_mem_samples.append(avg_mem)
+                gl_avg, gl_min, gl_max = self._calculate_metrics(
+                    self.gpu_load_samples
+                )
+                gm_avg, gm_min, gm_max = self._calculate_metrics(
+                    self.gpu_mem_samples
+                )
+                await statsd_client.gauge("gpu.load.avg", gl_avg)
+                await statsd_client.gauge("gpu.load.min", gl_min)
+                await statsd_client.gauge("gpu.load.max", gl_max)
+                await statsd_client.gauge("gpu.mem.avg", gm_avg)
+                await statsd_client.gauge("gpu.mem.min", gm_min)
+                await statsd_client.gauge("gpu.mem.max", gm_max)
 
 
 __all__ = ["TasksService"]

--- a/{{cookiecutter.project_slug}}/src/utils/metrics.py
+++ b/{{cookiecutter.project_slug}}/src/utils/metrics.py
@@ -12,6 +12,7 @@ class AsyncStatsDClient:
         self.host = host
         self.port = port
         self.counters: DefaultDict[str, int] = defaultdict(int)
+        self.gauges: DefaultDict[str, float] = defaultdict(float)
 
     async def _send(self, message: bytes) -> None:
         loop = asyncio.get_running_loop()
@@ -30,8 +31,17 @@ class AsyncStatsDClient:
             # Metrics should never crash the app
             pass
 
+    async def gauge(self, metric: str, value: float) -> None:
+        self.gauges[metric] = value
+        msg = f"{metric}:{value}|g".encode()
+        try:
+            await self._send(msg)
+        except Exception:
+            pass
+
     def reset(self) -> None:
         self.counters.clear()
+        self.gauges.clear()
 
 
 statsd_client = AsyncStatsDClient(settings.statsd.host, settings.statsd.port)


### PR DESCRIPTION
## Summary
- gauge statsd metrics
- capture cpu/memory/gpu usage in task service
- test resource metrics calculations

## Testing
- `pytest -q` *(fails: ImportError in tests due to unresolved placeholders)*
- `nox -s ci-3.12 ci-3.13` *(fails: dependency installation error)*

------
https://chatgpt.com/codex/tasks/task_e_6873baeb3b588330ab9717986dcd546f