### PR TITLE
Enable uvloop & async task handling

### DIFF
--- a/{{cookiecutter.project_slug}}/src/api/tasks.py
+++ b/{{cookiecutter.project_slug}}/src/api/tasks.py
@@ -4,6 +4,7 @@ import json
 from html import escape
 from typing import Any, Dict
 
+import asyncio
 from pydantic import BaseModel, Field, ValidationError
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -66,8 +67,8 @@ def get_router(service: TasksService | None = None) -> Router:
                     {"detail": exc.errors()}, status_code=HTTP_400_BAD_REQUEST
                 )
 
-            await service.enqueue_task(payload.model_dump())
-            await statsd_client.incr("requests.tasks")
+            asyncio.create_task(service.enqueue_task(payload.model_dump()))
+            asyncio.create_task(statsd_client.incr("requests.tasks"))
             return JSONResponse({"status": "accepted"}, status_code=HTTP_202_ACCEPTED)
 
     router.routes.append(Route("/tasks", create_task, methods=["POST"]))

--- a/{{cookiecutter.project_slug}}/src/main.py
+++ b/{{cookiecutter.project_slug}}/src/main.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import asyncio
+import uvloop
 
 # Add the project root (parent directory of 'src') to sys.path
 # This allows 'from src...' imports to work when running main.py directly
@@ -21,12 +23,15 @@ from `src.core.config.settings`. # Changed name.core.config to src.core.config
 
 import uvicorn
 
-from src.core.config import settings # Changed name.core.config to src.core.config
-from src.core.logging_config import get_logger # Changed name.core.logging_config to src.core.logging_config
+from src.core.config import settings  # Changed name.core.config to src.core.config
+from src.core.logging_config import (
+    get_logger,
+)  # Changed name.core.logging_config to src.core.logging_config
 
 log = get_logger(__name__)
 
 if __name__ == "__main__":
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
     log.info(
         f"Starting Uvicorn server on http://{settings.app_host}:{settings.app_port}"
     )

--- a/{{cookiecutter.project_slug}}/tests/conftest.py
+++ b/{{cookiecutter.project_slug}}/tests/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+import uvloop
 import os
 from typing import AsyncGenerator, Generator
 
@@ -46,6 +47,7 @@ async def stub_statsd(monkeypatch) -> AsyncGenerator[None, None]:
 
 @pytest.fixture(scope="session")
 def event_loop(request) -> Generator[asyncio.AbstractEventLoop, None, None]:
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
     loop = asyncio.get_event_loop_policy().new_event_loop()
     yield loop
     loop.close()

--- a/{{cookiecutter.project_slug}}/tests/integration/test_api_tasks.py
+++ b/{{cookiecutter.project_slug}}/tests/integration/test_api_tasks.py
@@ -1,6 +1,8 @@
 import pytest
 from httpx import AsyncClient
 from starlette import status
+import asyncio
+import uvloop
 
 from {{cookiecutter.python_package_name}}.utils import (
     TASKS_STREAM_NAME,
@@ -18,8 +20,10 @@ async def test_should_return_202_and_store_message(async_client: AsyncClient, fa
     payload = {"data": "hello", "metadata": {"foo": "bar"}}
 
     response = await async_client.post("/tasks", json=payload)
+    await asyncio.sleep(0)  # allow background task to complete
 
     assert response.status_code == status.HTTP_202_ACCEPTED
+    assert isinstance(asyncio.get_running_loop(), uvloop.Loop)
     assert TASKS_STREAM_NAME in fake_redis.streams
     assert fake_redis.streams[TASKS_STREAM_NAME]
     message = fake_redis.streams[TASKS_STREAM_NAME][-1]


### PR DESCRIPTION
## Summary
- activate uvloop in `main.py`
- enqueue tasks asynchronously
- adjust tests for uvloop event loop and background tasks

## Testing
- `nox -s ci-3.13 --error-on-missing-interpreters -v` *(fails: Failed to parse `pyproject.toml`)*
- `pytest -q` *(fails: SyntaxError in template placeholders)*

------
https://chatgpt.com/codex/tasks/task_e_6873bfa6b26483309c2b41df382312c4