### PR TITLE
Add documentation on configuration and shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,42 @@ The generated service exposes two endpoints:
 - `POST /tasks` – accepts a payload and stores a task in Redis Streams returning `202 Accepted`
 
 Additional helper scripts are located in the `scripts/` folder to automate systemd service creation.
+
+## Configuration
+
+Environment variables are loaded from `.env` using Pydantic settings. The most
+important ones are:
+
+- `APP_HOST` / `APP_PORT` – host and port for Uvicorn
+- `APP_RELOAD` – enable auto reloading
+- `APP_ENV` – environment name (`dev`, `prod`, `test`)
+- `REDIS_URL` – Redis connection string
+- `STATSD_HOST` / `STATSD_PORT` – StatsD exporter address
+- `JAEGER_HOST` / `JAEGER_PORT` – Jaeger collector endpoint
+- `LOG_LOKI_URL` – Loki push endpoint for logs
+
+The template ships with a `.env.example` file containing defaults.
+
+## Running with Docker Compose
+
+Launch the service together with Redis, StatsD, Jaeger and Loki:
+
+```bash
+docker-compose up -d
+```
+
+The compose file relies on the environment variables listed above, so adjust
+them if necessary.
+
+## Metrics and tracing
+
+Metrics are sent via a lightweight StatsD client defined in
+`src/utils/metrics.py`. When OpenTelemetry is available, traces are exported to
+Jaeger via `src/utils/tracing.py`. If `LOG_LOKI_URL` is set, structured logs are
+pushed to Loki.
+
+## Graceful shutdown
+
+`src/api/main.py` registers a shutdown handler that closes Redis connections,
+resets the StatsD client and clears collected spans before the application
+exits. This ensures a clean termination.

--- a/{{cookiecutter.project_slug}}/CHANGELOG.md
+++ b/{{cookiecutter.project_slug}}/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.1] - 2025-07-14
+
+- Documented required environment variables
+- Added instructions for running via Docker Compose
+- Explained metrics, tracing and graceful shutdown
+- Regenerated Sphinx documentation

--- a/{{cookiecutter.project_slug}}/docs/index.rst
+++ b/{{cookiecutter.project_slug}}/docs/index.rst
@@ -5,6 +5,37 @@ Welcome to name's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+Configuration
+-------------
+
+The service reads settings from environment variables via ``pydantic``.
+The most important variables are ``APP_HOST``, ``APP_PORT``, ``APP_ENV`` and
+``REDIS_URL``. Metrics and tracing can be configured using ``STATSD_HOST``,
+``STATSD_PORT``, ``JAEGER_HOST``, ``JAEGER_PORT`` and ``LOG_LOKI_URL``. See
+``.env.example`` for defaults.
+
+Running with Docker Compose
+---------------------------
+
+Start all dependencies together with the application:
+
+.. code-block:: bash
+
+   docker-compose up -d
+
+Metrics and tracing
+-------------------
+
+Metrics are sent via ``utils.metrics`` to a StatsD exporter. Traces are exported
+to Jaeger when OpenTelemetry is available using ``utils.tracing``. Logs can be
+forwarded to Loki if ``LOG_LOKI_URL`` is set.
+
+Graceful shutdown
+-----------------
+
+``api.main`` registers a shutdown handler that closes Redis connections, resets
+the metrics client and clears stored spans to ensure clean exit.
+
 Indices and tables
 ==================
 


### PR DESCRIPTION
## Summary
- document environment variables and Docker Compose
- explain metrics/tracing and graceful shutdown
- regenerate Sphinx docs
- update changelog

## Testing
- `pytest -q` *(fails: invalid syntax in template placeholders)*
- `nox -s ci-3.12 ci-3.13` *(fails: pyenv version not installed)*
- `sphinx-build -b html . _build/html`

------
https://chatgpt.com/codex/tasks/task_e_6873c3a901988330bf72c6cf22a06220