### PR TITLE
Add env vars for service configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ important ones are:
 - `REDIS_URL` – Redis connection string
 - `STATSD_HOST` / `STATSD_PORT` – StatsD exporter address
 - `JAEGER_HOST` / `JAEGER_PORT` – Jaeger collector endpoint
-- `LOG_LOKI_URL` – Loki push endpoint for logs
+- `LOKI_ENDPOINT` – Loki push endpoint for logs
 
 The template ships with a `.env.example` file containing defaults.
 
@@ -65,7 +65,7 @@ them if necessary.
 
 Metrics are sent via a lightweight StatsD client defined in
 `src/utils/metrics.py`. When OpenTelemetry is available, traces are exported to
-Jaeger via `src/utils/tracing.py`. If `LOG_LOKI_URL` is set, structured logs are
+Jaeger via `src/utils/tracing.py`. If `LOKI_ENDPOINT` is set, structured logs are
 pushed to Loki.
 
 ## Graceful shutdown

--- a/{{cookiecutter.project_slug}}/.env.example
+++ b/{{cookiecutter.project_slug}}/.env.example
@@ -6,8 +6,14 @@
 # --- Настройки приложения (Uvicorn и общие) ---
 APP_ENV="dev" # Окружение: dev, prod, test
 APP_HOST="0.0.0.0"
-APP_PORT="8000" # Порт, на котором приложение будет доступно на хосте
+APP_PORT="{{cookiecutter.app_port_host}}" # Порт, на котором приложение будет доступно на хосте
 APP_RELOAD="True" # Включить автоперезагрузку для Uvicorn (True/False)
+
+# --- Основные параметры сервиса ---
+SERVICE_NAME="{{cookiecutter.project_slug}}" # Имя сервиса, используется в логах и трейсе
+SERVICE_VERSION="{{cookiecutter.project_version}}" # Версия приложения
+SERVICE_HOST="0.0.0.0" # Адрес, на котором слушает приложение
+SERVICE_PORT="{{cookiecutter.internal_app_port}}" # Порт сервиса внутри контейнера
 
 
 # --- Настройки логирования (примеры, если они настраиваются через переменные окружения) ---
@@ -15,6 +21,28 @@ APP_RELOAD="True" # Включить автоперезагрузку для Uvi
 # LOG_LEVEL_FILE_INFO="INFO" # Уровень для info-файла
 # LOG_LEVEL_FILE_ERROR="ERROR" # Уровень для error-файла
 # LOG_PATH="/app/logs" # Путь для файлов логов внутри контейнера (если отличается от дефолта)
+
+# --- Настройки Redis ---
+REDIS_URL="redis://localhost:6379" # URL подключения к Redis
+REDIS_STREAM_NAME="tasks:stream" # Имя стрима для задач
+REDIS_CONSUMER_GROUP="processors" # Группа консьюмеров
+REDIS_CONSUMER_NAME="worker" # Имя конкретного консьюмера
+
+# --- Мониторинг и трассировка ---
+STATSD_HOST="localhost" # Хост StatsD сервера
+STATSD_PORT="8125" # Порт StatsD
+STATSD_PREFIX="microservice" # Префикс для метрик
+JAEGER_ENDPOINT="http://localhost:14268/api/traces" # HTTP endpoint Jaeger
+JAEGER_SERVICE_NAME="{{cookiecutter.project_slug}}" # Имя сервиса для Jaeger
+LOKI_ENDPOINT="http://localhost:3100/loki/api/v1/push" # Endpoint Loki
+
+# --- Параметры производительности ---
+UVLOOP_ENABLED="true" # Использовать ли uvloop
+WORKER_PROCESSES="auto" # Количество воркеров Uvicorn
+MAX_CONCURRENT_TASKS="1000" # Максимальное число фоновых задач
+TASK_TIMEOUT="30" # Тайм-аут обработки задачи, сек
+MAX_PAYLOAD_SIZE="1048576" # Максимальный размер тела запроса в байтах
+SHUTDOWN_TIMEOUT="30" # Время на graceful shutdown, сек
 
 # --- Другие настройки ---
 # SECRET_KEY="your_very_secret_key_here" # Пример для JWT или других нужд безопасности

--- a/{{cookiecutter.project_slug}}/docs/index.rst
+++ b/{{cookiecutter.project_slug}}/docs/index.rst
@@ -11,7 +11,7 @@ Configuration
 The service reads settings from environment variables via ``pydantic``.
 The most important variables are ``APP_HOST``, ``APP_PORT``, ``APP_ENV`` and
 ``REDIS_URL``. Metrics and tracing can be configured using ``STATSD_HOST``,
-``STATSD_PORT``, ``JAEGER_HOST``, ``JAEGER_PORT`` and ``LOG_LOKI_URL``. See
+``STATSD_PORT``, ``JAEGER_HOST``, ``JAEGER_PORT`` and ``LOKI_ENDPOINT``. See
 ``.env.example`` for defaults.
 
 Running with Docker Compose
@@ -28,7 +28,7 @@ Metrics and tracing
 
 Metrics are sent via ``utils.metrics`` to a StatsD exporter. Traces are exported
 to Jaeger when OpenTelemetry is available using ``utils.tracing``. Logs can be
-forwarded to Loki if ``LOG_LOKI_URL`` is set.
+forwarded to Loki if ``LOKI_ENDPOINT`` is set.
 
 Graceful shutdown
 -----------------

--- a/{{cookiecutter.project_slug}}/src/api/tasks.py
+++ b/{{cookiecutter.project_slug}}/src/api/tasks.py
@@ -19,12 +19,13 @@ from .deps import get_tasks_service
 from ..services.tasks_service import TasksService
 from ..utils.metrics import statsd_client
 from ..utils.tracing import tracer
+from ..core.config import settings
 
 
 tasks_service: TasksService = get_tasks_service()
 
 
-MAX_BODY_SIZE = 1_048_576
+MAX_BODY_SIZE = settings.performance.max_payload_size
 
 
 def _sanitize(value: Any) -> Any:

--- a/{{cookiecutter.project_slug}}/src/core/config.py
+++ b/{{cookiecutter.project_slug}}/src/core/config.py
@@ -35,7 +35,8 @@ class LogSettings(BaseSettings):
     diagnose: bool = True
     rotation: str = "00:00"
     retention: str = "7 days"
-    loki_url: str = "http://localhost:3100/loki/api/v1/push"
+    # Endpoint where logs should be pushed for aggregation
+    loki_endpoint: str = "http://localhost:3100/loki/api/v1/push"
 
 
 class RedisSettings(BaseSettings):
@@ -60,6 +61,7 @@ class StatsDSettings(BaseSettings):
 
     host: str = "localhost"
     port: int = 8125
+    prefix: str = "microservice"
 
 
 class JaegerSettings(BaseSettings):
@@ -69,6 +71,41 @@ class JaegerSettings(BaseSettings):
 
     host: str = "localhost"
     port: int = 14268
+
+    endpoint: str = "http://localhost:14268/api/traces"
+    # Name of the service as shown in Jaeger
+    service_name: str = "{{cookiecutter.project_slug}}"
+
+
+class ServiceSettings(BaseSettings):
+    """General service information and network settings."""
+
+    model_config = SettingsConfigDict(env_prefix="SERVICE_")
+
+    # Service identifier used in logs and traces
+    name: str = "{{cookiecutter.project_slug}}"
+    # Application version reported on startup
+    version: str = "{{cookiecutter.project_version}}"
+    host: str = "0.0.0.0"
+    # Internal port the app listens on
+    port: int = {{cookiecutter.internal_app_port}}
+
+
+class PerformanceSettings(BaseSettings):
+    """Runtime performance and tuning parameters."""
+
+    # Enable high performance event loop
+    uvloop_enabled: bool = True
+    # Number of Uvicorn worker processes
+    worker_processes: str = "auto"
+    # Limit for concurrent background tasks
+    max_concurrent_tasks: int = 1000
+    # Individual task timeout in seconds
+    task_timeout: int = 30
+    # Maximum allowed request payload size in bytes
+    max_payload_size: int = 1_048_576
+    # Graceful shutdown timeout in seconds
+    shutdown_timeout: int = 30
 
 
 class AppSettings(BaseSettings):
@@ -83,6 +120,8 @@ class AppSettings(BaseSettings):
     redis: RedisSettings = Field(default_factory=RedisSettings)
     statsd: StatsDSettings = Field(default_factory=StatsDSettings)
     jaeger: JaegerSettings = Field(default_factory=JaegerSettings)
+    service: ServiceSettings = Field(default_factory=ServiceSettings)
+    performance: PerformanceSettings = Field(default_factory=PerformanceSettings)
 
     app_host: str = Field(
         default="0.0.0.0", description="Host for Uvicorn"

--- a/{{cookiecutter.project_slug}}/src/core/logging_config.py
+++ b/{{cookiecutter.project_slug}}/src/core/logging_config.py
@@ -79,11 +79,11 @@ def setup_initial_logger() -> None:
             ]
         }
         try:
-            httpx.post(current_settings.log.loki_url, json=payload)
+            httpx.post(current_settings.log.loki_endpoint, json=payload)
         except Exception:
             pass
 
-    if current_settings.log.loki_url:
+    if current_settings.log.loki_endpoint:
         loguru_logger.add(
             _send_to_loki,
             format=_format_record,

--- a/{{cookiecutter.project_slug}}/src/main.py
+++ b/{{cookiecutter.project_slug}}/src/main.py
@@ -31,9 +31,11 @@ from src.core.logging_config import (
 log = get_logger(__name__)
 
 if __name__ == "__main__":
-    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    if settings.performance.uvloop_enabled:
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
     log.info(
-        f"Starting Uvicorn server on http://{settings.app_host}:{settings.app_port}"
+        f"Starting {settings.service.name} v{settings.service.version} on "
+        f"http://{settings.app_host}:{settings.app_port}"
     )
     log.info(f"Code auto-reloading: {'Enabled' if settings.app_reload else 'Disabled'}")
     log.info("Press CTRL+C to stop the server.")

--- a/{{cookiecutter.project_slug}}/src/utils/tracing.py
+++ b/{{cookiecutter.project_slug}}/src/utils/tracing.py
@@ -13,11 +13,12 @@ try:
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
     provider = TracerProvider(
-        resource=Resource.create({SERVICE_NAME: "simplemspy"})
+        resource=Resource.create({SERVICE_NAME: settings.jaeger.service_name})
     )
-    jaeger_exporter = JaegerExporter(
-        collector_endpoint=f"http://{settings.jaeger.host}:{settings.jaeger.port}/api/traces"
+    endpoint = settings.jaeger.endpoint or (
+        f"http://{settings.jaeger.host}:{settings.jaeger.port}/api/traces"
     )
+    jaeger_exporter = JaegerExporter(collector_endpoint=endpoint)
     provider.add_span_processor(BatchSpanProcessor(jaeger_exporter))
     trace.set_tracer_provider(provider)
     _otel_tracer = trace.get_tracer(__name__)

--- a/{{cookiecutter.project_slug}}/tests/unit/test_config.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_config.py
@@ -6,6 +6,7 @@ def test_log_settings_instantiation():
     assert log_settings.path == BASE_DIR / "logs"
     assert (BASE_DIR / "logs").exists()  # Check directory creation
     assert log_settings.console_level == "INFO"
+    assert log_settings.loki_endpoint.startswith("http")
 
 
 def test_log_settings_env_override(monkeypatch):
@@ -59,4 +60,26 @@ def test_jaeger_defaults():
     cfg = AppSettings()
     assert cfg.jaeger.host == "localhost"
     assert cfg.jaeger.port == 14268
+    assert cfg.jaeger.endpoint == "http://localhost:14268/api/traces"
+    assert cfg.jaeger.service_name == "{{cookiecutter.project_slug}}"
+
+
+def test_service_defaults():
+    cfg = AppSettings()
+    svc = cfg.service
+    assert svc.name == "{{cookiecutter.project_slug}}"
+    assert svc.version == "{{cookiecutter.project_version}}"
+    assert svc.host == "0.0.0.0"
+    assert svc.port == {{cookiecutter.internal_app_port}}
+
+
+def test_performance_defaults():
+    cfg = AppSettings()
+    perf = cfg.performance
+    assert perf.uvloop_enabled is True
+    assert perf.worker_processes == "auto"
+    assert perf.max_concurrent_tasks == 1000
+    assert perf.task_timeout == 30
+    assert perf.max_payload_size == 1_048_576
+    assert perf.shutdown_timeout == 30
 


### PR DESCRIPTION
## Summary
- define service, performance, jaeger and statsd parameters
- use new settings in tracing, tasks API and startup
- document variables in `.env.example`
- test new defaults for added settings

## Testing
- `pytest -q` *(fails: template placeholders cause SyntaxError)*
- `nox -f {{cookiecutter.project_slug}}/noxfile.py -s ci-3.12 ci-3.13` *(fails: invalid metadata parsing)*

------
https://chatgpt.com/codex/tasks/task_e_6873c4b9541883308c0660312c5caae0