### PR TITLE
Update docs and replace FastAPI references

### DIFF
--- a/{{cookiecutter.project_slug}}/src/api/deps.py
+++ b/{{cookiecutter.project_slug}}/src/api/deps.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Dependency providers for the API layer."""
+
 from ..core.config import settings
 from ..repository.redis_repo import RedisRepository
 from ..services.tasks_service import TasksService

--- a/{{cookiecutter.project_slug}}/src/api/main.py
+++ b/{{cookiecutter.project_slug}}/src/api/main.py
@@ -1,3 +1,5 @@
+"""Starlette application setup and lifecycle handlers."""
+
 from starlette.applications import Starlette
 from starlette.routing import Router
 
@@ -19,11 +21,15 @@ app = Starlette(routes=router.routes)
 
 @app.on_event("startup")
 async def on_startup() -> None:
+    """Log startup message."""
+
     log.info("Application startup")
 
 
 @app.on_event("shutdown")
 async def on_shutdown() -> None:
+    """Clean up resources on shutdown."""
+
     await _close_repo(health.redis_repo)
     await _close_repo(tasks.tasks_service.repo)
     statsd_client.reset()
@@ -32,6 +38,8 @@ async def on_shutdown() -> None:
 
 
 async def _close_repo(repo) -> None:
+    """Attempt to gracefully close a repository."""
+
     redis_obj = getattr(repo, "redis", repo)
     close = getattr(redis_obj, "close", None)
     if close:

--- a/{{cookiecutter.project_slug}}/src/core/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/core/__init__.py
@@ -1,3 +1,5 @@
+"""Core utilities exposed for convenience imports."""
+
 from .config import settings
 from .logging_config import get_logger
 

--- a/{{cookiecutter.project_slug}}/src/core/config.py
+++ b/{{cookiecutter.project_slug}}/src/core/config.py
@@ -1,3 +1,5 @@
+"""Application configuration models and settings loader."""
+
 import os
 from pathlib import Path
 from typing import Optional, Literal
@@ -126,7 +128,7 @@ class AppSettings(BaseSettings):
     app_host: str = Field(
         default="0.0.0.0", description="Host for Uvicorn"
     )  # Changed default to 0.0.0.0
-    app_port: int = Field(default=8000, description="Порт FastAPI приложения")
+    app_port: int = Field(default=8000, description="Порт Starlette приложения")
     app_reload: bool = Field(
         default=True, description="Enable/disable Uvicorn auto-reloading"
     )

--- a/{{cookiecutter.project_slug}}/src/core/logging_config.py
+++ b/{{cookiecutter.project_slug}}/src/core/logging_config.py
@@ -1,3 +1,5 @@
+"""Logging configuration helpers using ``loguru``."""
+
 import sys
 import logging
 import os
@@ -73,7 +75,7 @@ def setup_initial_logger() -> None:
         payload = {
             "streams": [
                 {
-                    "labels": "{app=\"simplemspy\"}",
+                    "labels": '{app="simplemspy"}',
                     "values": [[str(timestamp), formatted]],
                 }
             ]

--- a/{{cookiecutter.project_slug}}/src/main.py
+++ b/{{cookiecutter.project_slug}}/src/main.py
@@ -9,16 +9,12 @@ PROJECT_ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT_DIR not in sys.path:
     sys.path.insert(0, PROJECT_ROOT_DIR)
 
-"""
-Main entry point for running the FastAPI application using Uvicorn.
+"""Application entry point.
 
-This file can be used to run the application directly:
-  `python src/main.py`
-
-Or passed to Uvicorn for execution:
-  `uvicorn src.api:app --reload`  # Changed name.api:app to src.api:app
-This `main.py` provides a convenient way to launch with settings
-from `src.core.config.settings`. # Changed name.core.config to src.core.config
+This module launches the Starlette application via Uvicorn. It can be run
+directly with ``python src/main.py`` or provided to ``uvicorn`` using the
+``src.api:app`` path. Configuration is pulled from
+``src.core.config.settings``.
 """
 
 import uvicorn
@@ -41,7 +37,7 @@ if __name__ == "__main__":
     log.info("Press CTRL+C to stop the server.")
 
     uvicorn.run(
-        "src.api:app",  # Path to the FastAPI application object, Changed name.api:app to src.api:app
+        "src.api:app",  # Path to the Starlette application object
         host=settings.app_host,
         port=settings.app_port,
         reload=settings.app_reload,

--- a/{{cookiecutter.project_slug}}/src/models/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/models/__init__.py
@@ -1,2 +1,3 @@
-# Models package
+"""Database models package."""
+
 # Import application models here for discovery by tooling.

--- a/{{cookiecutter.project_slug}}/src/pythonjsonlogger/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/pythonjsonlogger/__init__.py
@@ -1,3 +1,5 @@
+"""Minimal JSON logging formatter used for tests."""
+
 from .jsonlogger import JsonFormatter
 
 __all__ = ["JsonFormatter"]

--- a/{{cookiecutter.project_slug}}/src/pythonjsonlogger/jsonlogger.py
+++ b/{{cookiecutter.project_slug}}/src/pythonjsonlogger/jsonlogger.py
@@ -1,6 +1,9 @@
+"""Custom JSON logging formatter for simplified output."""
+
 import json
 import logging
 from typing import Any, Dict
+
 
 class JsonFormatter(logging.Formatter):
     """Minimal JSON formatter used for testing."""

--- a/{{cookiecutter.project_slug}}/src/repository/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/repository/__init__.py
@@ -1,0 +1,1 @@
+"""Repository implementations for external services."""

--- a/{{cookiecutter.project_slug}}/src/repository/redis_repo.py
+++ b/{{cookiecutter.project_slug}}/src/repository/redis_repo.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Redis repository used for queue operations."""
+
 from datetime import timedelta
 from typing import Any, Dict, Optional
 

--- a/{{cookiecutter.project_slug}}/src/services/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer containing business logic classes."""

--- a/{{cookiecutter.project_slug}}/src/utils/metrics.py
+++ b/{{cookiecutter.project_slug}}/src/utils/metrics.py
@@ -1,3 +1,5 @@
+"""Simple asynchronous StatsD client."""
+
 import asyncio
 from collections import defaultdict
 from typing import DefaultDict
@@ -9,12 +11,16 @@ class AsyncStatsDClient:
     """Very small async StatsD client using UDP."""
 
     def __init__(self, host: str, port: int) -> None:
+        """Initialize the client."""
+
         self.host = host
         self.port = port
         self.counters: DefaultDict[str, int] = defaultdict(int)
         self.gauges: DefaultDict[str, float] = defaultdict(float)
 
     async def _send(self, message: bytes) -> None:
+        """Send a raw UDP message."""
+
         loop = asyncio.get_running_loop()
         transport, _ = await loop.create_datagram_endpoint(
             lambda: asyncio.DatagramProtocol(), remote_addr=(self.host, self.port)
@@ -23,6 +29,8 @@ class AsyncStatsDClient:
         transport.close()
 
     async def incr(self, metric: str, value: int = 1) -> None:
+        """Increment a counter."""
+
         self.counters[metric] += value
         msg = f"{metric}:{value}|c".encode()
         try:
@@ -32,6 +40,8 @@ class AsyncStatsDClient:
             pass
 
     async def gauge(self, metric: str, value: float) -> None:
+        """Submit a gauge value."""
+
         self.gauges[metric] = value
         msg = f"{metric}:{value}|g".encode()
         try:
@@ -40,6 +50,8 @@ class AsyncStatsDClient:
             pass
 
     def reset(self) -> None:
+        """Clear stored metrics."""
+
         self.counters.clear()
         self.gauges.clear()
 

--- a/{{cookiecutter.project_slug}}/src/utils/redis_stream.py
+++ b/{{cookiecutter.project_slug}}/src/utils/redis_stream.py
@@ -1,3 +1,5 @@
+"""Thin wrapper around Redis Stream operations."""
+
 from typing import Any, Dict
 
 from redis.asyncio import Redis

--- a/{{cookiecutter.project_slug}}/src/utils/tracing.py
+++ b/{{cookiecutter.project_slug}}/src/utils/tracing.py
@@ -1,3 +1,5 @@
+"""Simplified tracing utilities with optional OpenTelemetry integration."""
+
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -42,6 +44,8 @@ class DummyTracer:
 
     @contextmanager
     def start_as_current_span(self, name: str) -> Generator[Span, None, None]:
+        """Start and record a span."""
+
         span = Span(name=name, start=time.time())
         self.spans.append(span)
         try:
@@ -58,6 +62,8 @@ class OtelTracer(DummyTracer):
 
     @contextmanager
     def start_as_current_span(self, name: str) -> Generator[Span, None, None]:
+        """Start a span using OpenTelemetry."""
+
         start_time = time.time()
         with _otel_tracer.start_as_current_span(name):
             span = Span(name=name, start=start_time)


### PR DESCRIPTION
## Summary
- replace `FastAPI` mentions with `Starlette`
- add module docstrings in the `src` tree

## Testing
- `pytest -q` *(fails: `pyenv: version {{cookiecutter.python_version}} is not installed`)*
- `nox -s ci-3.12 ci-3.13` *(fails: `command not found: nox`)*
- `ruff format`

------
https://chatgpt.com/codex/tasks/task_e_6873d2acdd3c8330b8b3d169a6a8d787