### PR TITLE
Fix template docs build with psutil

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/index.rst
+++ b/{{cookiecutter.project_slug}}/docs/index.rst
@@ -1,5 +1,5 @@
-Welcome to name's documentation!
-==================================
+Welcome to {{cookiecutter.project_name}}'s documentation!
+{{ '=' * ('Welcome to ' ~ cookiecutter.project_name ~ "'s documentation!" | length) }}
 
 .. toctree::
    :maxdepth: 2

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "inflection>=0.5.1", # For string case conversions (e.g., table names)
     "redis>=6.2.0",
     "aiobreaker>=1.2.0",
+    "psutil>=7.0.0",
     "uvloop>=0.21.0",
 ]
 


### PR DESCRIPTION
## Summary
- add psutil to default dependencies
- fix docs heading underline in the template

## Testing
- `nox -s docs` *(fails: Title underline too short)*
- `nox -s build` *(fails: Docker not running)*

------
https://chatgpt.com/codex/tasks/task_e_687632f1ff848330b4aa8ab03e9bd93f