### PR TITLE
Improve StatsD client and docs

### DIFF
--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -1,0 +1,23 @@
+# {{cookiecutter.project_name}}
+
+{{cookiecutter.project_description}}
+
+## Development quick start
+
+Install dependencies using [uv](https://github.com/astral-sh/uv):
+
+```bash
+uv sync
+```
+
+Run linters and tests:
+
+```bash
+nox -s ci-3.12 ci-3.13
+```
+
+Start the application for development:
+
+```bash
+uv run src/{{cookiecutter.python_package_name}}/main.py
+```

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/main.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/main.py
@@ -33,6 +33,7 @@ async def on_shutdown() -> None:
     """Clean up resources on shutdown."""
     await _close_repo(health.redis_repo)
     await _close_repo(tasks.tasks_service.repo)
+    await statsd_client.close()
     statsd_client.reset()
     tracer.spans.clear()
     log.info("Application shutdown complete")

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/core/logging_config.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/core/logging_config.py
@@ -56,10 +56,9 @@ def setup_initial_logger() -> None:
 
     def _send_to_loki(message: Any) -> None:
         record = message.record
-        formatted = json.dumps({
-            "message": record.get("message", ""),
-            "level": record["level"].name,
-        })
+        formatted = json.dumps(
+            {"message": record.get("message", ""), "level": record["level"].name}
+        )
         timestamp = int(record["time"].timestamp() * 1_000_000_000)
         payload = {
             "streams": [
@@ -76,8 +75,7 @@ def setup_initial_logger() -> None:
 
     if current_settings.log.loki_endpoint:
         loguru_logger.add(
-            _send_to_loki,
-            level=current_settings.log.console_level.upper(),
+            _send_to_loki, level=current_settings.log.console_level.upper()
         )
 
     logging.basicConfig(handlers=[InterceptHandler()], level=0, force=True)

--- a/{{cookiecutter.project_slug}}/tests/integration/test_shutdown.py
+++ b/{{cookiecutter.project_slug}}/tests/integration/test_shutdown.py
@@ -33,4 +33,5 @@ async def test_should_flush_and_close_on_shutdown(monkeypatch) -> None:
 
     assert fake.closed and fake.waited
     assert statsd_client.counters == {}
+    assert statsd_client._transport is None
     assert tracer.spans == []


### PR DESCRIPTION
## Summary
- keep UDP transport open in AsyncStatsDClient
- close StatsD client during shutdown
- test that StatsD client transport closes
- add README template for generated projects
- format logging config

## Testing
- `ruff check src tests`
- `pytest -q tests/unit/test_logging_config.py::test_logger_outputs_json`
- `nox -s ci-3.12 ci-3.13`

------
https://chatgpt.com/codex/tasks/task_e_6876420baca08330a671d029a5f7965b