### PR TITLE
Fix metrics calculation for empty list

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/tasks_service.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/tasks_service.py
@@ -33,6 +33,9 @@ class TasksService:
     @staticmethod
     def _calculate_metrics(values: List[float]) -> Tuple[float, float, float]:
         """Return average, min and max for provided values."""
+        if not values:
+            return 0.0, 0.0, 0.0
+
         avg = sum(values) / len(values)
         return avg, min(values), max(values)
 

--- a/{{cookiecutter.project_slug}}/tests/unit/test_tasks_service.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_tasks_service.py
@@ -29,6 +29,13 @@ def test_calculate_metrics() -> None:
     assert mx == 3.0
 
 
+def test_calculate_metrics_empty_list() -> None:
+    avg, mn, mx = TasksService._calculate_metrics([])
+    assert avg == 0.0
+    assert mn == 0.0
+    assert mx == 0.0
+
+
 @pytest.mark.asyncio
 async def test_should_report_average_min_max_metrics(monkeypatch) -> None:
     cpu_values = iter([10.0, 30.0])


### PR DESCRIPTION
## Summary
- handle empty list in metrics calc
- test edge case for metrics

## Testing
- `PYENV_VERSION=3.13.3 nox -s ci-3.12 ci-3.13` *(fails: Command uv pip install -e '.[lint]')*

------
https://chatgpt.com/codex/tasks/task_e_6876696b2f648330872cb04523b4e0c2