### PR TITLE
Fix coverage and tooling defaults

### DIFF
--- a/{{cookiecutter.project_slug}}/.mise.toml
+++ b/{{cookiecutter.project_slug}}/.mise.toml
@@ -1,0 +1,2 @@
+[settings]
+idiomatic_version_file_enable_tools = ["python"]

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -101,7 +101,7 @@ package = true
 [tool.ruff]
 line-length = 88
 indent-width = 4
-target-version = "py310"
+target-version = "py313"
 exclude = [
     ".git",
     "__pycache__",
@@ -237,7 +237,7 @@ skip_empty = true
 show_missing = true
 
 [tool.coverage.paths]
-source = ["src", "{full_path_to_src}"]
+source = ["src"]
 
 
 # --- pytest ---


### PR DESCRIPTION
## Summary
- enable `.python-version` support with mise config
- target Python 3.13 for ruff
- simplify coverage path mapping

## Testing
- `nox -s ci-3.12 ci-3.13 -f {{cookiecutter.project_slug}}/noxfile.py` *(fails: uv pip install)*
- `pytest -q` *(fails: SyntaxError in template placeholders)*

------
https://chatgpt.com/codex/tasks/task_e_687674b0cc1c8330be9eb47968ec3341