### PR TITLE
Fix GPU metrics collection

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/tasks_service.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/tasks_service.py
@@ -69,7 +69,11 @@ class TasksService:
         await statsd_client.gauge("mem.max", mem_max)
 
         if GPU_AVAILABLE and GPUtil is not None:
-            gpus = cast(List[Any], GPUtil.getGPUs())  # pyright: ignore[reportUnknownMemberType]
+            try:
+                gpus = cast(List[Any], GPUtil.getGPUs())  # pyright: ignore[reportUnknownMemberType]
+            except Exception:
+                gpus = []
+
             if gpus:
                 loads = [float(getattr(g, "load", 0)) * 100 for g in gpus]
                 mems = [float(getattr(g, "memoryUtil", 0)) * 100 for g in gpus]


### PR DESCRIPTION
## Summary
- add try/except around GPU usage metric collection

## Testing
- `ruff check src/{{cookiecutter.python_package_name}}/services/tasks_service.py`
- `pytest -q` *(fails: ImportError due to unresolved cookiecutter placeholders)*
- `nox -s ci-3.12 ci-3.13` *(fails: cannot install project dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687674b0cc1c8330be9eb47968ec3341