### PR TITLE
Fix redis message encoding

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/tasks_service.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/tasks_service.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Tuple, cast
 from uuid import uuid4
 
+import json
 import psutil
 
 try:
@@ -44,8 +45,8 @@ class TasksService:
         message = {
             "task_id": str(uuid4()),
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "payload": payload,
-            "trace_context": {"trace_id": "", "span_id": ""},
+            "payload": json.dumps(payload),
+            "trace_context": json.dumps({"trace_id": "", "span_id": ""}),
         }
         result = await self.repo.add_to_stream(TASKS_STREAM_NAME, message)
         await self._record_usage()

--- a/{{cookiecutter.project_slug}}/tests/integration/test_api_tasks.py
+++ b/{{cookiecutter.project_slug}}/tests/integration/test_api_tasks.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 from starlette import status
 import asyncio
+import json
 
 from {{cookiecutter.python_package_name}}.utils import (
     TASKS_STREAM_NAME,
@@ -25,7 +26,7 @@ async def test_should_return_202_and_store_message(async_client: AsyncClient, fa
     assert TASKS_STREAM_NAME in fake_redis.streams
     assert fake_redis.streams[TASKS_STREAM_NAME]
     message = fake_redis.streams[TASKS_STREAM_NAME][-1]
-    assert message["payload"] == payload
+    assert json.loads(message["payload"]) == payload
     assert statsd_client.counters["requests.tasks"] == 1
     assert tracer.spans and tracer.spans[-1].name == "create_task"
 

--- a/{{cookiecutter.project_slug}}/tests/unit/test_tasks_service.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_tasks_service.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 
 from {{cookiecutter.python_package_name}}.repository.redis_repo import RedisRepository
@@ -17,7 +18,7 @@ async def test_enqueue_task_formats_and_stores_message() -> None:
 
     assert TASKS_STREAM_NAME in fake.streams
     stored = fake.streams[TASKS_STREAM_NAME][0]
-    assert stored["payload"] == payload
+    assert json.loads(stored["payload"]) == payload
     assert "task_id" in stored
     assert "timestamp" in stored
 


### PR DESCRIPTION
## Summary
- encode task payload as JSON before storing in Redis
- adjust tests for encoded payload

## Testing
- `uv run nox -s ci-3.13 -s ci-3.12` *(fails: coverage < 80%)*
- `nox -s ci-3.12 ci-3.13` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68767e46385483308b681cd2b3fa378f