### PR TITLE
Fix Docker CMD path

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -78,4 +78,4 @@ EXPOSE {{cookiecutter.internal_app_port}}
 # Для простоты, здесь можно захардкодить порт, на котором Uvicorn слушает внутри контейнера,
 # а маппинг на хостовой порт делать в docker-compose.yml.
 # Пусть Uvicorn внутри контейнера всегда слушает на 8000.
-CMD ["/opt/venv/bin/python", "-m", "uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "{{cookiecutter.internal_app_port}}"]
+CMD ["/opt/venv/bin/python", "-m", "uvicorn", "{{cookiecutter.python_package_name}}.api:app", "--host", "0.0.0.0", "--port", "{{cookiecutter.internal_app_port}}"]


### PR DESCRIPTION
## Summary
- fix Docker `CMD` to reference the package path

## Testing
- `pytest -q` *(fails: invalid syntax due to template placeholders)*
- `nox -f {{cookiecutter.project_slug}}/noxfile.py -s ci-3.12` *(fails: invalid package name in pyproject)*

------
https://chatgpt.com/codex/tasks/task_e_687683ac07f08330af483fb1481fbc7e