### PR TITLE
Add restart policy to compose services

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ Launch the service together with Redis, StatsD, Jaeger and Loki:
 docker-compose up -d
 ```
 
-The compose file relies on the environment variables listed above, so adjust
-them if necessary.
+Containers use `restart: unless-stopped` so they will automatically start on
+host reboot. The compose file relies on the environment variables listed above,
+so adjust them if necessary.
 
 ## Metrics and tracing
 

--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    restart: unless-stopped
     ports:
       - "${APP_PORT:-{{cookiecutter.app_port_host}}}:{{cookiecutter.internal_app_port}}"
     env_file:
@@ -21,12 +22,14 @@ services:
     image: redis:7-alpine
     ports:
       - "6379:6379"
+    restart: unless-stopped
     networks:
       - app_network
   statsd:
     image: prom/statsd-exporter:latest
     ports:
       - "8125:8125/udp"
+    restart: unless-stopped
     networks:
       - app_network
   jaeger:
@@ -34,6 +37,7 @@ services:
     ports:
       - "16686:16686"
       - "14268:14268"
+    restart: unless-stopped
     networks:
       - app_network
   loki:
@@ -41,6 +45,7 @@ services:
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
+    restart: unless-stopped
     networks:
       - app_network
 

--- a/{{cookiecutter.project_slug}}/docs/index.rst
+++ b/{{cookiecutter.project_slug}}/docs/index.rst
@@ -22,6 +22,9 @@ Start all dependencies together with the application:
 
    docker-compose up -d
 
+Services use ``restart: unless-stopped`` so they will automatically start on
+host reboot.
+
 Metrics and tracing
 -------------------
 


### PR DESCRIPTION
## Summary
- ensure containers restart automatically by adding `restart: unless-stopped`
- mention automatic restart in README and docs

## Testing
- `nox -s ci-3.12 ci-3.13` *(fails: Failed to parse metadata from built wheel)*

------
https://chatgpt.com/codex/tasks/task_e_68768a7fcae48330a9f125dc63b08d76