### PR TITLE
Remove aiobreaker dependency

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/repository/redis_repo.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/repository/redis_repo.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any, Dict, cast
 
-import aiobreaker
+from ..utils import CircuitBreaker, CircuitBreakerError
 
 from redis.asyncio import Redis
 
@@ -21,7 +21,7 @@ class RedisRepository:
     ) -> None:
         # Redis.from_url may lack type hints in some versions
         self.redis = client or Redis.from_url(url, decode_responses=True)  # pyright: ignore[reportUnknownMemberType]
-        self.breaker: aiobreaker.CircuitBreaker = aiobreaker.CircuitBreaker(
+        self.breaker: CircuitBreaker = CircuitBreaker(
             fail_max=settings.redis.breaker_fail_max,
             timeout_duration=timedelta(seconds=settings.redis.breaker_reset_timeout),
         )

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/__init__.py
@@ -3,6 +3,7 @@
 from .metrics import statsd_client
 from .redis_stream import RedisStream, TASKS_STREAM_NAME, redis_stream
 from .tracing import tracer
+from .circuitbreaker import CircuitBreaker, CircuitBreakerError
 
 __all__ = [
     "TASKS_STREAM_NAME",
@@ -10,4 +11,6 @@ __all__ = [
     "redis_stream",
     "statsd_client",
     "tracer",
+    "CircuitBreaker",
+    "CircuitBreakerError",
 ]

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/circuitbreaker.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/circuitbreaker.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Simple asynchronous circuit breaker implementation."""
+
+from datetime import datetime, timedelta
+from typing import Awaitable, Callable, Optional, TypeVar
+
+
+class CircuitBreakerError(Exception):
+    """Raised when the circuit is open."""
+
+
+T = TypeVar("T")
+
+
+class CircuitBreaker:
+    """Minimal async circuit breaker."""
+
+    def __init__(self, fail_max: int, timeout_duration: timedelta) -> None:
+        self.fail_max = fail_max
+        self.timeout_duration = timeout_duration
+        self._failure_count = 0
+        self._opened_until: Optional[datetime] = None
+
+    async def call_async(
+        self, func: Callable[..., Awaitable[T]], *args: object, **kwargs: object
+    ) -> T:
+        if self._opened_until and datetime.now() < self._opened_until:
+            raise CircuitBreakerError("circuit breaker is open")
+
+        try:
+            result = await func(*args, **kwargs)
+        except Exception:
+            self._failure_count += 1
+            if self._failure_count >= self.fail_max:
+                self._opened_until = datetime.now() + self.timeout_duration
+                self._failure_count = 0
+                raise CircuitBreakerError("circuit breaker is open")
+            raise
+        else:
+            self._failure_count = 0
+            self._opened_until = None
+            return result
+
+__all__ = ["CircuitBreaker", "CircuitBreakerError"]
+

--- a/{{cookiecutter.project_slug}}/tests/unit/test_redis_repo.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_redis_repo.py
@@ -1,6 +1,8 @@
 import pytest
 
-import aiobreaker
+from {{cookiecutter.python_package_name}}.utils.circuitbreaker import (
+    CircuitBreakerError,
+)
 
 from {{cookiecutter.python_package_name}}.repository.redis_repo import (
     RedisRepository,
@@ -42,5 +44,5 @@ async def test_should_open_breaker_after_failures() -> None:
             await repo.add_to_stream("s", {"foo": "bar"})
 
     # third call should trip the breaker
-    with pytest.raises(aiobreaker.CircuitBreakerError):
+    with pytest.raises(CircuitBreakerError):
         await repo.add_to_stream("s", {"foo": "bar"})


### PR DESCRIPTION
## Summary
- implement a lightweight async CircuitBreaker
- export CircuitBreaker helpers
- use new CircuitBreaker in RedisRepository
- adjust RedisRepository tests

## Testing
- `pytest tests/unit/test_redis_repo.py::test_should_open_breaker_after_failures -q` *(fails: ImportError while loading conftest due to template placeholders)*

------
https://chatgpt.com/codex/tasks/task_e_6876948636b4833099061c5fc7f20f24