### PR TITLE
Fix template Dockerfile

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -35,6 +35,8 @@ COPY ./ ./
 # Если uv.lock существует, uv sync его использует. Иначе, он может попытаться разрешить зависимости из pyproject.toml.
 # Предполагаем, что uv.lock будет сгенерирован и будет основным источником.
 RUN uv sync --frozen
+# Install the project itself to ensure dependencies from ``pyproject.toml`` are included
+RUN uv pip install -e .
 # Добавил --no-dev для уменьшения образа, если это поддерживается uv sync или pip install для проекта.
 # Добавил --frozen-lockfile для uv sync, чтобы он падал, если lock не соответствует toml.
 


### PR DESCRIPTION
## Summary
- fix docker build by installing the project after syncing dependencies

## Testing
- `nox -f {{cookiecutter.project_slug}}/noxfile.py -s ci-3.12 ci-3.13` *(fails: uv pip install -e '.[lint]' failed)*

------
https://chatgpt.com/codex/tasks/task_e_6876998d22f48330bd9fc68a56df5b09