### PR TITLE
Add Redis stream cookiecutter settings

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -14,6 +14,9 @@
   "repo_name": "{{cookiecutter.project_slug}}",
   "copyright_year": "2024",
   "log_directory": "logs",
+  "redis_stream_name": "tasks:stream",
+  "redis_consumer_group": "processors",
+  "redis_consumer_name": "worker",
   "_copy_without_render": [
     "*.html",
     "docs/_static/*"

--- a/{{cookiecutter.project_slug}}/.env.example
+++ b/{{cookiecutter.project_slug}}/.env.example
@@ -24,9 +24,9 @@ SERVICE_PORT="{{cookiecutter.internal_app_port}}" # Порт сервиса вн
 
 # --- Настройки Redis ---
 REDIS_URL="redis://redis:6379/0" # URL подключения к Redis внутри Docker Compose
-REDIS_STREAM_NAME="tasks:stream" # Имя стрима для задач
-REDIS_CONSUMER_GROUP="processors" # Группа консьюмеров
-REDIS_CONSUMER_NAME="worker" # Имя конкретного консьюмера
+REDIS_STREAM_NAME="{{cookiecutter.redis_stream_name}}" # Имя стрима для задач
+REDIS_CONSUMER_GROUP="{{cookiecutter.redis_consumer_group}}" # Группа консьюмеров
+REDIS_CONSUMER_NAME="{{cookiecutter.redis_consumer_name}}" # Имя конкретного консьюмера
 
 # --- Мониторинг и трассировка ---
 STATSD_HOST="statsd" # Хост StatsD сервера

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/core/config.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/core/config.py
@@ -70,9 +70,9 @@ class RedisSettings(BaseSettings):
 
     # Default to the Docker Compose service hostname
     url: str = "redis://redis:6379/0"
-    stream_name: str = "tasks:stream"
-    consumer_group: str = "processors"
-    consumer_name: str = f"{os.getenv('HOSTNAME', 'local')}:{os.getpid()}"
+    stream_name: str = "{{cookiecutter.redis_stream_name}}"
+    consumer_group: str = "{{cookiecutter.redis_consumer_group}}"
+    consumer_name: str = "{{cookiecutter.redis_consumer_name}}"
     max_length: int = 100_000
     retention_ms: int = 3_600_000
     breaker_fail_max: int = 3

--- a/{{cookiecutter.project_slug}}/tests/unit/test_config.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_config.py
@@ -41,7 +41,9 @@ def test_redis_settings_defaults():
     settings = AppSettings()
     redis = settings.redis
     assert redis.url.startswith("redis://")
-    assert redis.stream_name == "tasks:stream"
+    assert redis.stream_name == "{{cookiecutter.redis_stream_name}}"
+    assert redis.consumer_group == "{{cookiecutter.redis_consumer_group}}"
+    assert redis.consumer_name == "{{cookiecutter.redis_consumer_name}}"
 
 
 def test_redis_settings_env_override(monkeypatch):


### PR DESCRIPTION
## Summary
- add Redis stream settings to the template
- expose these defaults through config
- update tests for new defaults

## Testing
- `pytest -q {{cookiecutter.project_slug}}/tests/unit/test_config.py` *(fails: SyntaxError)*
- `nox -f '{{cookiecutter.project_slug}}/noxfile.py' -s ci-3.12 ci-3.13` *(fails to install deps)*

------
https://chatgpt.com/codex/tasks/task_e_6876c239e4608330959e0c2cf96d355a