### PR TITLE
Make tasks endpoint configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This repository provides a cookiecutter template for creating a small high-perfo
 
 The generated service exposes two endpoints:
 - `GET /health` – health information
-- `POST /tasks` – accepts a payload and stores a task in Redis Streams returning `202 Accepted`
+- `POST {{cookiecutter.tasks_endpoint_path}}` – accepts a payload and stores a task in Redis Streams returning `202 Accepted`
 
 Additional helper scripts are located in the `scripts/` folder to automate systemd service creation.
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -17,6 +17,7 @@
   "redis_stream_name": "tasks:stream",
   "redis_consumer_group": "processors",
   "redis_consumer_name": "worker",
+  "tasks_endpoint_path": "/tasks",
   "_copy_without_render": [
     "*.html",
     "docs/_static/*"

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/tasks.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/tasks.py
@@ -21,6 +21,7 @@ from .deps import get_tasks_service
 from ..services.tasks_service import TasksService
 from ..utils.metrics import statsd_client
 from ..utils.tracing import tracer
+from ..utils import TASKS_ENDPOINT_PATH
 from ..core.config import settings
 from ..core.logging_config import get_logger
 
@@ -80,7 +81,7 @@ def get_router(service: TasksService | None = None) -> Router:
             the global ``tasks_service``.
 
     Returns:
-        Router with the ``/tasks`` route registered.
+        Router with the ``TASKS_ENDPOINT_PATH`` route registered.
     """
     service = service or tasks_service
     router = Router()
@@ -128,7 +129,9 @@ def get_router(service: TasksService | None = None) -> Router:
             task_metric.add_done_callback(_log_task_result)
             return JSONResponse({"status": "accepted"}, status_code=HTTP_202_ACCEPTED)
 
-    router.routes.append(Route("/tasks", create_task, methods=["POST"]))
+    router.routes.append(
+        Route(TASKS_ENDPOINT_PATH, create_task, methods=["POST"])
+    )
     return router
 
 

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/core/config.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/core/config.py
@@ -116,6 +116,8 @@ class ServiceSettings(BaseSettings):
     host: str = "0.0.0.0"
     # Internal port the app listens on
     port: int = {{cookiecutter.internal_app_port}}
+    # Path for task creation endpoint
+    tasks_endpoint: str = "{{cookiecutter.tasks_endpoint_path}}"
 
 
 class PerformanceSettings(BaseSettings):

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utility helpers for the application."""
 
+from ..core.config import settings
 from .metrics import statsd_client
 from .redis_stream import RedisStream, TASKS_STREAM_NAME, redis_stream
 from .tracing import tracer
@@ -9,8 +10,11 @@ __all__ = [
     "TASKS_STREAM_NAME",
     "RedisStream",
     "redis_stream",
+    "TASKS_ENDPOINT_PATH",
     "statsd_client",
     "tracer",
     "CircuitBreaker",
     "CircuitBreakerError",
 ]
+
+TASKS_ENDPOINT_PATH = settings.service.tasks_endpoint

--- a/{{cookiecutter.project_slug}}/tests/integration/test_api_tasks.py
+++ b/{{cookiecutter.project_slug}}/tests/integration/test_api_tasks.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 
 from {{cookiecutter.python_package_name}}.utils import (
+    TASKS_ENDPOINT_PATH,
     TASKS_STREAM_NAME,
     statsd_client,
     tracer,
@@ -19,7 +20,7 @@ async def test_should_return_202_and_store_message(async_client: AsyncClient, fa
     tracer.spans.clear()
     payload = {"data": "hello", "metadata": {"foo": "bar"}}
 
-    response = await async_client.post("/tasks", json=payload)
+    response = await async_client.post(TASKS_ENDPOINT_PATH, json=payload)
     await asyncio.sleep(0)  # allow background task to complete
 
     assert response.status_code == status.HTTP_202_ACCEPTED
@@ -32,7 +33,7 @@ async def test_should_return_202_and_store_message(async_client: AsyncClient, fa
 
 
 async def test_should_return_400_when_payload_invalid(async_client: AsyncClient):
-    response = await async_client.post("/tasks", json={"foo": "bar"})
+    response = await async_client.post(TASKS_ENDPOINT_PATH, json={"foo": "bar"})
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -40,7 +41,7 @@ async def test_should_return_400_when_payload_invalid(async_client: AsyncClient)
 async def test_should_return_413_when_payload_too_large(async_client: AsyncClient):
     big_data = "x" * (1024 * 1024 + 1)
     response = await async_client.post(
-        "/tasks",
+        TASKS_ENDPOINT_PATH,
         json={"data": big_data, "metadata": {}},
     )
 


### PR DESCRIPTION
## Summary
- configure tasks endpoint path via cookiecutter
- expose constant `TASKS_ENDPOINT_PATH`
- update API router and tests to use the constant
- document configurable endpoint in README

## Testing
- `pytest -q` *(fails: invalid syntax due to cookiecutter placeholders)*
- `nox -f {{cookiecutter.project_slug}}/noxfile.py -s ci-3.12 ci-3.13` *(fails: could not install deps due to invalid metadata)*

------
https://chatgpt.com/codex/tasks/task_e_6877777750c48330b4a6580776450454