### PR TITLE
Add StatsD prefix support

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/metrics.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/metrics.py
@@ -10,13 +10,17 @@ from ..core.config import settings
 class AsyncStatsDClient:
     """Very small async StatsD client using UDP."""
 
-    def __init__(self, host: str, port: int) -> None:
+    def __init__(self, host: str, port: int, prefix: str = "") -> None:
         """Initialize the client."""
         self.host = host
         self.port = port
+        self.prefix = prefix
         self.counters: DefaultDict[str, int] = defaultdict(int)
         self.gauges: DefaultDict[str, float] = defaultdict(float)
         self._transport: asyncio.DatagramTransport | None = None
+
+    def _format(self, metric: str) -> str:
+        return f"{self.prefix}.{metric}" if self.prefix else metric
 
     async def _ensure_transport(self) -> None:
         if self._transport is None:
@@ -40,7 +44,7 @@ class AsyncStatsDClient:
     async def incr(self, metric: str, value: int = 1) -> None:
         """Increment a counter."""
         self.counters[metric] += value
-        msg = f"{metric}:{value}|c".encode()
+        msg = f"{self._format(metric)}:{value}|c".encode()
         try:
             await self._send(msg)
         except Exception:
@@ -50,7 +54,7 @@ class AsyncStatsDClient:
     async def gauge(self, metric: str, value: float) -> None:
         """Submit a gauge value."""
         self.gauges[metric] = value
-        msg = f"{metric}:{value}|g".encode()
+        msg = f"{self._format(metric)}:{value}|g".encode()
         try:
             await self._send(msg)
         except Exception:
@@ -62,6 +66,8 @@ class AsyncStatsDClient:
         self.gauges.clear()
 
 
-statsd_client = AsyncStatsDClient(settings.statsd.host, settings.statsd.port)
+statsd_client = AsyncStatsDClient(
+    settings.statsd.host, settings.statsd.port, settings.statsd.prefix
+)
 
 __all__ = ["AsyncStatsDClient", "statsd_client"]

--- a/{{cookiecutter.project_slug}}/tests/unit/test_config.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_config.py
@@ -55,7 +55,7 @@ def test_redis_settings_env_override(monkeypatch):
 def test_statsd_defaults():
     cfg = AppSettings()
     assert cfg.statsd.host == "statsd"
-    assert cfg.statsd.port == 8125
+    assert cfg.statsd.port == 9125
 
 
 def test_jaeger_defaults():


### PR DESCRIPTION
## Summary
- include configurable metric prefix in AsyncStatsDClient
- update StatsD default port test

## Testing
- `pytest -q` *(fails: SyntaxError in conftest due to template placeholders)*
- `nox -s ci-3.12 ci-3.13` *(fails: `uv pip install -e .[lint]` can't parse metadata)*

------
https://chatgpt.com/codex/tasks/task_e_68778aa4b66883309fbbe244b99386d0