### PR TITLE
Add StatsD prefix support

### DIFF
--- a/{{cookiecutter.project_slug}}/tests/unit/test_metrics.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_metrics.py
@@ -1,0 +1,20 @@
+import asyncio
+import pytest
+
+from {{cookiecutter.python_package_name}}.utils.metrics import AsyncStatsDClient
+
+
+@pytest.mark.asyncio
+async def test_should_apply_prefix_to_metric_name() -> None:
+    messages: list[bytes] = []
+
+    async def capture(self, message: bytes) -> None:
+        messages.append(message)
+
+    client = AsyncStatsDClient("localhost", 8125, prefix="pref")
+    client._send = capture.__get__(client, AsyncStatsDClient)
+    await client.incr("my.metric", 2)
+    await client.gauge("another", 1.5)
+
+    assert messages[0].startswith(b"pref.my.metric:2|c")
+    assert messages[1].startswith(b"pref.another:1.5|g")


### PR DESCRIPTION
## Summary
- allow configuring a metric prefix in `AsyncStatsDClient`
- instantiate `AsyncStatsDClient` with prefix from settings
- test that the prefix is applied

## Testing
- `nox -s ci-3.12 -vv` *(fails: Failed to parse metadata from built wheel)*
- `nox -s ci-3.13 -vv` *(fails: Failed to parse metadata from built wheel)*
- `python3 -m pytest -q` *(fails: SyntaxError in tests due to placeholders)*

------
https://chatgpt.com/codex/tasks/task_e_68778aa4b66883309fbbe244b99386d0