### PR TITLE
Fix Jaeger instrumentation

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "aiobreaker>=1.2.0",
     "psutil>=7.0.0",
     "uvloop>=0.21.0",
+    "opentelemetry-sdk>=1.23.0",
+    "opentelemetry-exporter-jaeger>=1.23.0",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- add OpenTelemetry SDK and Jaeger exporter as default dependencies

## Testing
- `PYENV_VERSION=3.13.3 nox -s ci-3.12 ci-3.13` *(fails: Failed to parse metadata from built wheel)*

------
https://chatgpt.com/codex/tasks/task_e_68779c42b1c88330ab3d55faba163cd2