### PR TITLE
Fix Jaeger tracing

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "uvloop",
     "opentelemetry-sdk",
     "opentelemetry-exporter-jaeger",
+    "deprecated",
 ]
 
 [build-system]

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/tracing.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/tracing.py
@@ -33,12 +33,12 @@ try:
     ot_trace.set_tracer_provider(provider)
     _otel_tracer: Any = ot_trace.get_tracer(__name__)
     use_otel = True
-except Exception:
+except Exception as exc:
     # If OpenTelemetry initialization fails, fall back to a dummy tracer and
     # log the reason to stderr so that tracing issues are visible in logs.
     import sys
 
-    print("OpenTelemetry disabled", file=sys.stderr)
+    print(f"OpenTelemetry disabled: {exc}", file=sys.stderr)
     use_otel = False
 
 


### PR DESCRIPTION
## Summary
- add `deprecated` to dependencies for Jaeger exporter
- log initialization errors when setting up OpenTelemetry

## Testing
- `nox -s ci-3.12 ci-3.13` *(fails: pyenv version `{{cookiecutter.python_version}}` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6877b53ed00c83308e4b5f70dd43767a