### PR TITLE
Fix template lint issues

### DIFF
--- a/{{cookiecutter.project_slug}}/noxfile.py
+++ b/{{cookiecutter.project_slug}}/noxfile.py
@@ -38,15 +38,13 @@ PYTHON_VERSIONS: List[str] = ["3.12", "3.13"]
 SRC_DIR: str = "src"
 TESTS_DIR: str = "tests"
 DOCS_DIR: str = "docs"
-COVERAGE_FAIL_UNDER: int = (
-    80  # Минимальный процент покрытия для тестов
-)
+COVERAGE_FAIL_UNDER: int = 80  # Минимальный процент покрытия для тестов
 os.environ["PYTHONDONTWRITEBYTECODE"] = "1"
 
 
 # --- Вспомогательные функции ---
 def install_project_with_deps(session: Session, *groups: str) -> None:
-    """Устанавливает проект и его зависимости из указанных групп используя uv pip install.""" # Docstring updated
+    """Устанавливает проект и его зависимости из указанных групп используя uv pip install."""  # Docstring updated
     install_args: List[str] = (
         ["-e", f".[{','.join(groups)}]"] if groups else ["-e", "."]
     )
@@ -203,17 +201,11 @@ def build(session: Session) -> None:
 @nox.session(python=False)
 def compose_rebuild(session: Session) -> None:
     """Полностью пересобирает окружение Docker Compose."""
-
     image_name: str = "{{cookiecutter.project_slug}}-app"
 
     session.log("Остановка и очистка старых контейнеров...")
     session.run(
-        "docker",
-        "compose",
-        "down",
-        "--volumes",
-        "--remove-orphans",
-        external=True,
+        "docker", "compose", "down", "--volumes", "--remove-orphans", external=True
     )
 
     session.log(f"Удаление старого образа {image_name}...")
@@ -223,14 +215,7 @@ def compose_rebuild(session: Session) -> None:
     session.run("docker", "builder", "prune", "-a", external=True)
 
     session.log("Пересборка образов без кэша...")
-    session.run(
-        "docker",
-        "compose",
-        "build",
-        "--no-cache",
-        "--pull",
-        external=True,
-    )
+    session.run("docker", "compose", "build", "--no-cache", "--pull", external=True)
 
     session.log("Запуск контейнеров...")
     session.run("docker", "compose", "up", external=True)

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/__init__.py
@@ -3,7 +3,7 @@
 from .core.config import settings
 from .core.logging_config import get_logger
 
-__all__ = ["__version__", "settings", "get_logger"]
+__all__ = ["__version__", "get_logger", "settings"]
 
 log = get_logger(__name__)
 

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/health.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/health.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Health check endpoint definitions."""
 
-from datetime import datetime, timezone
+from datetime import datetime
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route, Router
@@ -51,7 +51,7 @@ def get_router(repo: RedisRepository | None = None) -> Router:
 
             payload = {
                 "status": "healthy" if redis_ok else "unhealthy",
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": datetime.now(datetime.UTC).isoformat(),
                 "redis_connected": redis_ok,
                 "version": __version__,
             }

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/core/logging_config.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/core/logging_config.py
@@ -17,7 +17,7 @@ _logger_initialized = False
 from .config import settings, AppSettings
 
 
-loguru_logger.disable("httpx")      # убираем httpx из Loguru совсем
+loguru_logger.disable("httpx")  # убираем httpx из Loguru совсем
 logging.getLogger("httpx").handlers = [logging.NullHandler()]
 logging.getLogger("httpx").propagate = False
 
@@ -42,7 +42,6 @@ class InterceptHandler(logging.Handler):
 
 
 def setup_initial_logger() -> None:
-    global _logger_initialized
     loguru_logger.remove()
 
     loguru_logger.level("DEBUG", color="<bold><white>")
@@ -92,7 +91,7 @@ def setup_initial_logger() -> None:
         )
 
     logging.basicConfig(handlers=[InterceptHandler()], level=0, force=True)
-    _logger_initialized = True
+    globals()["_logger_initialized"] = True
 
     def _patch_uvicorn_loggers() -> None:
         """
@@ -108,7 +107,7 @@ def setup_initial_logger() -> None:
 
 
 # Exported helpers
-__all__ = ["InterceptHandler", "setup_initial_logger", "get_logger"]
+__all__ = ["InterceptHandler", "get_logger", "setup_initial_logger"]
 
 
 def get_logger(name: str) -> Any:

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/repository/redis_repo.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/repository/redis_repo.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any, Dict, cast
 
-from ..utils import CircuitBreaker, CircuitBreakerError, tracer
+from ..utils import CircuitBreaker, tracer
 
 from redis.asyncio import Redis
 
@@ -30,19 +30,14 @@ class RedisRepository:
         """Add a message to a Redis Stream."""
         with tracer.start_as_current_span("redis_add_to_stream"):
             result: Any = await self.breaker.call_async(
-                self.redis.xadd,
-                stream_name,
-                message,
-                maxlen=settings.redis.max_length,
+                self.redis.xadd, stream_name, message, maxlen=settings.redis.max_length
             )  # pyright: ignore[reportUnknownMemberType,reportUnknownArgumentType]
             return cast(str, result)
 
     async def ping(self) -> bool:
         """Check Redis connectivity."""
         with tracer.start_as_current_span("redis_ping"):
-            result: Any = await self.breaker.call_async(
-                self.redis.ping
-            )  # pyright: ignore[reportUnknownMemberType]
+            result: Any = await self.breaker.call_async(self.redis.ping)  # pyright: ignore[reportUnknownMemberType]
             return cast(bool, result)
 
 

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/schemas/common.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/schemas/common.py
@@ -46,7 +46,7 @@ class PaginationParams(BaseModel):
     )
 
 
-class PaginatedResponse(BaseModel, Generic[T]):
+class PaginatedResponse[T](BaseModel):
     """Generic schema for paginated API responses."""
 
     items: List[T] = Field(..., description="List of items on the current page")

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/tasks_service.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/tasks_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Service providing task queueing and metric collection."""
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Dict, List, Tuple, cast
 from uuid import uuid4
 
@@ -49,7 +49,7 @@ class TasksService:
         with tracer.start_as_current_span("enqueue_task"):
             message = {
                 "task_id": str(uuid4()),
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": datetime.now(datetime.UTC).isoformat(),
                 "payload": json.dumps(payload),
                 "trace_context": json.dumps({"trace_id": "", "span_id": ""}),
             }

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/__init__.py
@@ -7,14 +7,14 @@ from .tracing import tracer
 from .circuitbreaker import CircuitBreaker, CircuitBreakerError
 
 __all__ = [
-    "TASKS_STREAM_NAME",
-    "RedisStream",
-    "redis_stream",
-    "TASKS_ENDPOINT_PATH",
-    "statsd_client",
-    "tracer",
     "CircuitBreaker",
     "CircuitBreakerError",
+    "RedisStream",
+    "TASKS_ENDPOINT_PATH",
+    "TASKS_STREAM_NAME",
+    "redis_stream",
+    "statsd_client",
+    "tracer",
 ]
 
 TASKS_ENDPOINT_PATH = settings.service.tasks_endpoint

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/circuitbreaker.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/circuitbreaker.py
@@ -22,7 +22,7 @@ class CircuitBreaker:
         self.fail_max = fail_max
         self.timeout_duration = timeout_duration
         self._failure_count = 0
-        self._opened_until: Optional[datetime] = None
+        self._opened_until: datetime | None = None
 
     async def call_async(
         self, func: Callable[..., Awaitable[T]], *args: object, **kwargs: object
@@ -33,17 +33,17 @@ class CircuitBreaker:
 
             try:
                 result = await func(*args, **kwargs)
-            except Exception:
+            except Exception as exc:
                 self._failure_count += 1
                 if self._failure_count >= self.fail_max:
                     self._opened_until = datetime.now() + self.timeout_duration
                     self._failure_count = 0
-                    raise CircuitBreakerError("circuit breaker is open")
+                    raise CircuitBreakerError("circuit breaker is open") from exc
                 raise
             else:
                 self._failure_count = 0
                 self._opened_until = None
                 return result
 
-__all__ = ["CircuitBreaker", "CircuitBreakerError"]
 
+__all__ = ["CircuitBreaker", "CircuitBreakerError"]

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/tracing.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/tracing.py
@@ -102,4 +102,5 @@ def shutdown_tracer() -> None:
         except Exception:
             pass
 
-__all__ = ["DummyTracer", "Span", "tracer", "shutdown_tracer"]
+
+__all__ = ["DummyTracer", "Span", "shutdown_tracer", "tracer"]

--- a/{{cookiecutter.project_slug}}/tests/unit/test_config.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_config.py
@@ -1,4 +1,4 @@
-from {{cookiecutter.python_package_name}}.core.config import LogSettings, AppSettings, BASE_DIR, DATA_DIR
+from {{cookiecutter.python_package_name}}.core.config import LogSettings, AppSettings, DATA_DIR
 
 
 def test_log_settings_instantiation():

--- a/{{cookiecutter.project_slug}}/tests/unit/test_logging_config.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_logging_config.py
@@ -10,7 +10,7 @@ from {{cookiecutter.python_package_name}}.core import config
 def test_should_post_logs_to_loki(monkeypatch):
     posted: dict[str, Any] = {}
 
-    def fake_post(url: str, *, json: Any) -> None:  # type: ignore[override]
+    def fake_post(url: str, *, json: Any, **_: Any) -> None:  # type: ignore[override]
         posted["url"] = url
         posted["json"] = json
 
@@ -46,7 +46,8 @@ def test_get_logger_with_empty_name():
     assert hasattr(logger_instance, "info")
 
 
-def test_logger_outputs_json(capsys):
+def test_logger_outputs_json(monkeypatch, capsys):
+    monkeypatch.setattr(config.settings.log, "loki_endpoint", "")
     setup_initial_logger()
     loguru_logger.info("json message")
     captured = capsys.readouterr().err.strip().splitlines()[-1]

--- a/{{cookiecutter.project_slug}}/tests/unit/test_metrics.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_metrics.py
@@ -1,4 +1,3 @@
-import asyncio
 import pytest
 
 from {{cookiecutter.python_package_name}}.utils.metrics import AsyncStatsDClient
@@ -10,7 +9,8 @@ async def test_should_apply_prefix_to_metric_name() -> None:
     messages: list[bytes] = []
 
     async def capture(self, message: bytes) -> None:
-        messages.append(message)
+        with tracer.start_as_current_span("statsd_send"):
+            messages.append(message)
 
     client = AsyncStatsDClient("localhost", 8125, prefix="pref")
     client._send = capture.__get__(client, AsyncStatsDClient)

--- a/{{cookiecutter.project_slug}}/tests/unit/test_redis_repo.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_redis_repo.py
@@ -23,7 +23,9 @@ async def test_should_add_to_stream_and_ping() -> None:
     assert await repo.ping()
     assert [s.name for s in tracer.spans] == [
         "redis_add_to_stream",
+        "circuitbreaker_call",
         "redis_ping",
+        "circuitbreaker_call",
     ]
 
 

--- a/{{cookiecutter.project_slug}}/tests/unit/test_schemas.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_schemas.py
@@ -1,5 +1,5 @@
 import pytest
-from datetime import datetime, timezone
+from datetime import datetime
 
 from pydantic import BaseModel, ValidationError
 
@@ -34,7 +34,7 @@ def test_id_model_schema():
 
 
 def test_timestamp_model_schema():
-    now = datetime.now(timezone.utc)
+    now = datetime.now(datetime.UTC)
     data = {"created_at": now, "updated_at": now}
     ts_instance = TimestampModel(**data)
     assert ts_instance.created_at == now


### PR DESCRIPTION
## Summary
- sort exported items
- update timestamp handling
- tidy logging config
- adjust tests for Loki and spans
- clean up unused imports and typing

## Testing
- `pytest -q {{cookiecutter.project_slug}}/tests/unit` *(fails: invalid syntax due to placeholders)*
- `nox -s ci-3.12 ci-3.13` *(fails: no noxfile found)*
- `ruff format {{cookiecutter.project_slug}}/src {{cookiecutter.project_slug}}/tests {{cookiecutter.project_slug}}/noxfile.py` *(fails: template placeholders cause parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877bcf15a4c8330b39aad40a26f1e2d