### PR TITLE
fix: update template for py312

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/health.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/health.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Health check endpoint definitions."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route, Router

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/core/config.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/core/config.py
@@ -52,7 +52,7 @@ class LogSettings(BaseSettings):
     info_file_level: str = "INFO"
     error_file_level: str = "ERROR"
     compression: str | None = None
-    enqueue: bool = True
+    enqueue: bool = False
     backtrace: bool = True
     diagnose: bool = True
     rotation: str = "00:00"

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/schemas/common.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/schemas/common.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Generic, List, TypeVar, ClassVar
+from typing import List, TypeVar, ClassVar
 
 from pydantic import BaseModel, Field, ConfigDict
 

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/tasks_service.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/tasks_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Service providing task queueing and metric collection."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, Dict, List, Tuple, cast
 from uuid import uuid4
 

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/__init__.py
@@ -7,11 +7,11 @@ from .tracing import tracer
 from .circuitbreaker import CircuitBreaker, CircuitBreakerError
 
 __all__ = [
+    "TASKS_ENDPOINT_PATH",
+    "TASKS_STREAM_NAME",
     "CircuitBreaker",
     "CircuitBreakerError",
     "RedisStream",
-    "TASKS_ENDPOINT_PATH",
-    "TASKS_STREAM_NAME",
     "redis_stream",
     "statsd_client",
     "tracer",

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/circuitbreaker.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/circuitbreaker.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Simple asynchronous circuit breaker implementation."""
 
 from datetime import datetime, timedelta
-from typing import Awaitable, Callable, Optional, TypeVar
+from typing import Awaitable, Callable, TypeVar
 
 from .tracing import tracer
 


### PR DESCRIPTION
## Summary
- import `UTC` from `datetime` for Python 3.12
- make ruff happy with `__all__` sorting
- drop unused imports
- disable async log sink by default

## Testing
- `pytest -q` *(fails: invalid syntax because placeholders)*


------
https://chatgpt.com/codex/tasks/task_e_6878a0edca348330b87e89d156a8ed79