### PR TITLE
Fix UTC constant usage in templates

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/health.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/health.py
@@ -51,7 +51,7 @@ def get_router(repo: RedisRepository | None = None) -> Router:
 
             payload = {
                 "status": "healthy" if redis_ok else "unhealthy",
-                "timestamp": datetime.now(datetime.UTC).isoformat(),
+                "timestamp": datetime.now(UTC).isoformat(),
                 "redis_connected": redis_ok,
                 "version": __version__,
             }

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/tasks_service.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/tasks_service.py
@@ -49,7 +49,7 @@ class TasksService:
         with tracer.start_as_current_span("enqueue_task"):
             message = {
                 "task_id": str(uuid4()),
-                "timestamp": datetime.now(datetime.UTC).isoformat(),
+                "timestamp": datetime.now(UTC).isoformat(),
                 "payload": json.dumps(payload),
                 "trace_context": json.dumps({"trace_id": "", "span_id": ""}),
             }

--- a/{{cookiecutter.project_slug}}/tests/unit/test_schemas.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_schemas.py
@@ -1,5 +1,5 @@
 import pytest
-from datetime import datetime
+from datetime import UTC, datetime
 
 from pydantic import BaseModel, ValidationError
 
@@ -34,7 +34,7 @@ def test_id_model_schema():
 
 
 def test_timestamp_model_schema():
-    now = datetime.now(datetime.UTC)
+    now = datetime.now(UTC)
     data = {"created_at": now, "updated_at": now}
     ts_instance = TimestampModel(**data)
     assert ts_instance.created_at == now


### PR DESCRIPTION
## Summary
- correct UTC timezone usage in health and task service modules
- update timestamp schema test to use UTC constant

## Testing
- `nox -s ci-3.12 --no-error-on-missing-interpreters` *(fails: Failed to parse metadata from built wheel)*

------
https://chatgpt.com/codex/tasks/task_e_6878a3c5c52c833092cf7c4ddcd97919