### PR TITLE
Translate tracing span names to Russian

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/health.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/health.py
@@ -41,7 +41,7 @@ def get_router(repo: RedisRepository | None = None) -> Router:
         Returns:
             JSONResponse with health metadata.
         """
-        with tracer.start_as_current_span("health_check"):
+        with tracer.start_as_current_span("проверка_здоровья"):
             await statsd_client.incr("requests.health")
             try:
                 await repo.ping()

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/main.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/main.py
@@ -26,14 +26,14 @@ app = Starlette(routes=router.routes)
 @app.on_event("startup")  # pyright: ignore[reportUnknownMemberType,reportUntypedFunctionDecorator]
 async def on_startup() -> None:
     """Log startup message."""
-    with tracer.start_as_current_span("startup"):
+    with tracer.start_as_current_span("запуск"):
         log.info("Application startup")
 
 
 @app.on_event("shutdown")  # pyright: ignore[reportUnknownMemberType,reportUntypedFunctionDecorator]
 async def on_shutdown() -> None:
     """Clean up resources on shutdown."""
-    with tracer.start_as_current_span("shutdown"):
+    with tracer.start_as_current_span("остановка"):
         await _close_repo(health.redis_repo)
         await _close_repo(tasks.tasks_service.repo)
         await statsd_client.close()
@@ -45,7 +45,7 @@ async def on_shutdown() -> None:
 
 async def _close_repo(repo: RedisRepository | Any) -> None:
     """Attempt to gracefully close a repository."""
-    with tracer.start_as_current_span("close_repo"):
+    with tracer.start_as_current_span("закрытие_репозитория"):
         redis_obj = getattr(repo, "redis", repo)
         close = getattr(redis_obj, "close", None)
         if close:

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/tasks.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/tasks.py
@@ -54,7 +54,7 @@ def _sanitize(value: Any) -> Any:
     Returns:
         The sanitized value.
     """
-    with tracer.start_as_current_span("sanitize"):
+    with tracer.start_as_current_span("очистка"):
         if isinstance(value, str):
             return escape(value)
         if isinstance(value, Sequence) and not isinstance(
@@ -87,7 +87,7 @@ def get_router(service: TasksService | None = None) -> Router:
         Router with the ``TASKS_ENDPOINT_PATH`` route registered.
     """
     service = service or tasks_service
-    with tracer.start_as_current_span("get_router"):
+    with tracer.start_as_current_span("получение_роутера"):
         router = Router()
 
     async def create_task(request: Request) -> JSONResponse:
@@ -100,7 +100,7 @@ def get_router(service: TasksService | None = None) -> Router:
         Returns:
             JSONResponse indicating acceptance or validation error.
         """
-        with tracer.start_as_current_span("create_task"):
+        with tracer.start_as_current_span("создание_задачи"):
             body = await request.body()
             if len(body) > MAX_BODY_SIZE:
                 return JSONResponse(

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/main.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/main.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     log.info(f"Code auto-reloading: {'Enabled' if settings.app_reload else 'Disabled'}")
     log.info("Press CTRL+C to stop the server.")
 
-    with tracer.start_as_current_span("main"):
+    with tracer.start_as_current_span("главная"):
         uvicorn.run(
             "{{cookiecutter.python_package_name}}.api:app",  # Path to the Starlette application object
             host=settings.app_host,

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/repository/redis_repo.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/repository/redis_repo.py
@@ -28,7 +28,7 @@ class RedisRepository:
 
     async def add_to_stream(self, stream_name: str, message: Dict[str, Any]) -> str:
         """Add a message to a Redis Stream."""
-        with tracer.start_as_current_span("redis_add_to_stream"):
+        with tracer.start_as_current_span("добавление_в_redis_стрим"):
             result: Any = await self.breaker.call_async(
                 cast(Callable[..., Awaitable[Any]], self.redis.xadd),
                 stream_name,
@@ -39,7 +39,7 @@ class RedisRepository:
 
     async def ping(self) -> bool:
         """Check Redis connectivity."""
-        with tracer.start_as_current_span("redis_ping"):
+        with tracer.start_as_current_span("пинг_redis"):
             result: Any = await self.breaker.call_async(
                 cast(Callable[..., Awaitable[Any]], self.redis.ping)
             )

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/tasks_service.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/tasks_service.py
@@ -37,7 +37,7 @@ class TasksService:
     @staticmethod
     def _calculate_metrics(values: List[float]) -> Tuple[float, float, float]:
         """Return average, min and max for provided values."""
-        with tracer.start_as_current_span("calculate_metrics"):
+        with tracer.start_as_current_span("расчет_метрик"):
             if not values:
                 return 0.0, 0.0, 0.0
 
@@ -46,7 +46,7 @@ class TasksService:
 
     async def enqueue_task(self, payload: Dict[str, Any]) -> str:
         """Serialize payload and push it to Redis."""
-        with tracer.start_as_current_span("enqueue_task"):
+        with tracer.start_as_current_span("постановка_задачи"):
             message = {
                 "task_id": str(uuid4()),
                 "timestamp": datetime.now(UTC).isoformat(),
@@ -63,7 +63,7 @@ class TasksService:
 
     async def _record_usage(self) -> None:
         """Record CPU, memory and GPU usage to StatsD."""
-        with tracer.start_as_current_span("record_usage"):
+        with tracer.start_as_current_span("запись_использования"):
             cpu = psutil.cpu_percent()
             mem = psutil.virtual_memory().percent
             self.cpu_samples.append(cpu)

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/circuitbreaker.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/circuitbreaker.py
@@ -27,7 +27,7 @@ class CircuitBreaker:
     async def call_async(
         self, func: Callable[..., Awaitable[T]], *args: object, **kwargs: object
     ) -> T:
-        with tracer.start_as_current_span("circuitbreaker_call"):
+        with tracer.start_as_current_span("вызов_предохранителя"):
             if self._opened_until and datetime.now() < self._opened_until:
                 raise CircuitBreakerError("circuit breaker is open")
 

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/metrics.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/metrics.py
@@ -33,7 +33,7 @@ class AsyncStatsDClient:
 
     async def _ensure_transport(self) -> None:
         if self._transport is None:
-            with tracer.start_as_current_span("statsd_ensure_transport"):
+            with tracer.start_as_current_span("statsd_обеспечение_транспорта"):
                 loop = asyncio.get_running_loop()
                 self._transport, _ = await loop.create_datagram_endpoint(
                     lambda: asyncio.DatagramProtocol(),
@@ -42,7 +42,7 @@ class AsyncStatsDClient:
 
     async def _send(self, message: bytes) -> None:
         """Send a raw UDP message."""
-        with tracer.start_as_current_span("statsd_send"):
+        with tracer.start_as_current_span("statsd_отправка"):
             await self._ensure_transport()
             assert self._transport is not None
             self._transport.sendto(message)
@@ -50,13 +50,13 @@ class AsyncStatsDClient:
     async def close(self) -> None:
         """Close the underlying transport if open."""
         if self._transport is not None:
-            with tracer.start_as_current_span("statsd_close"):
+            with tracer.start_as_current_span("statsd_закрытие"):
                 self._transport.close()
                 self._transport = None
 
     async def incr(self, metric: str, value: int = 1) -> None:
         """Increment a counter."""
-        with tracer.start_as_current_span("statsd_incr"):
+        with tracer.start_as_current_span("statsd_инкремент"):
             self.counters[metric] += value
             msg_metric = self._format_name(metric)
             msg = f"{msg_metric}:{value}|c".encode()
@@ -68,7 +68,7 @@ class AsyncStatsDClient:
 
     async def gauge(self, metric: str, value: float) -> None:
         """Submit a gauge value."""
-        with tracer.start_as_current_span("statsd_gauge"):
+        with tracer.start_as_current_span("statsd_измерение"):
             self.gauges[metric] = value
             msg_metric = self._format_name(metric)
             msg = f"{msg_metric}:{value}|g".encode()
@@ -79,7 +79,7 @@ class AsyncStatsDClient:
 
     def reset(self) -> None:
         """Clear stored metrics."""
-        with tracer.start_as_current_span("statsd_reset"):
+        with tracer.start_as_current_span("statsd_сброс"):
             self.counters.clear()
             self.gauges.clear()
 

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/redis_stream.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/redis_stream.py
@@ -17,7 +17,7 @@ class RedisStream:
         self.redis: Redis = Redis.from_url(url, decode_responses=True)  # pyright: ignore[reportUnknownMemberType,reportInvalidTypeArguments]
 
     async def xadd(self, stream_name: str, fields: Dict[str, Any]) -> str:
-        with tracer.start_as_current_span("redis_stream_xadd"):
+        with tracer.start_as_current_span("добавление_в_redis_stream"):
             result: Any = await self.redis.xadd(
                 stream_name, fields, maxlen=settings.redis.max_length
             )  # pyright: ignore[reportUnknownMemberType]
@@ -25,7 +25,7 @@ class RedisStream:
 
     async def ping(self) -> bool:
         """Check if Redis connection is alive."""
-        with tracer.start_as_current_span("redis_stream_ping"):
+        with tracer.start_as_current_span("пинг_redis_stream"):
             result: Any = await self.redis.ping()  # pyright: ignore[reportUnknownMemberType]
             return cast(bool, result)
 

--- a/{{cookiecutter.project_slug}}/tests/integration/test_api_health.py
+++ b/{{cookiecutter.project_slug}}/tests/integration/test_api_health.py
@@ -22,7 +22,7 @@ async def test_health_check(async_client: AsyncClient):
     assert isinstance(data["redis_connected"], bool)
     assert isinstance(data["version"], str) and data["version"]
     assert statsd_client.counters["requests.health"] == 1
-    assert tracer.spans and tracer.spans[0].name == "health_check"
+    assert tracer.spans and tracer.spans[0].name == "проверка_здоровья"
 
 
 async def test_should_return_503_when_redis_unavailable(
@@ -45,4 +45,4 @@ async def test_should_return_503_when_redis_unavailable(
     assert isinstance(data["timestamp"], str)
     assert isinstance(data["version"], str) and data["version"]
     assert statsd_client.counters["requests.health"] == 1
-    assert tracer.spans and tracer.spans[0].name == "health_check"
+    assert tracer.spans and tracer.spans[0].name == "проверка_здоровья"

--- a/{{cookiecutter.project_slug}}/tests/integration/test_api_tasks.py
+++ b/{{cookiecutter.project_slug}}/tests/integration/test_api_tasks.py
@@ -29,7 +29,7 @@ async def test_should_return_202_and_store_message(async_client: AsyncClient, fa
     message = fake_redis.streams[TASKS_STREAM_NAME][-1]
     assert json.loads(message["payload"]) == payload
     assert statsd_client.counters["requests.tasks"] == 1
-    assert tracer.spans and tracer.spans[0].name == "create_task"
+    assert tracer.spans and tracer.spans[0].name == "создание_задачи"
 
 
 async def test_should_return_400_when_payload_invalid(async_client: AsyncClient):

--- a/{{cookiecutter.project_slug}}/tests/unit/test_metrics.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_metrics.py
@@ -9,7 +9,7 @@ async def test_should_apply_prefix_to_metric_name() -> None:
     messages: list[bytes] = []
 
     async def capture(self, message: bytes) -> None:
-        with tracer.start_as_current_span("statsd_send"):
+        with tracer.start_as_current_span("statsd_отправка"):
             messages.append(message)
 
     client = AsyncStatsDClient("localhost", 8125, prefix="pref")
@@ -21,8 +21,8 @@ async def test_should_apply_prefix_to_metric_name() -> None:
     assert messages[0].startswith(b"pref.my.metric:2|c")
     assert messages[1].startswith(b"pref.another:1.5|g")
     assert [s.name for s in tracer.spans] == [
-        "statsd_incr",
-        "statsd_send",
-        "statsd_gauge",
-        "statsd_send",
+        "statsd_инкремент",
+        "statsd_отправка",
+        "statsd_измерение",
+        "statsd_отправка",
     ]

--- a/{{cookiecutter.project_slug}}/tests/unit/test_redis_repo.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_redis_repo.py
@@ -22,10 +22,10 @@ async def test_should_add_to_stream_and_ping() -> None:
     assert fake.streams["mystream"][0]["foo"] == "bar"
     assert await repo.ping()
     assert [s.name for s in tracer.spans] == [
-        "redis_add_to_stream",
-        "circuitbreaker_call",
-        "redis_ping",
-        "circuitbreaker_call",
+        "добавление_в_redis_стрим",
+        "вызов_предохранителя",
+        "пинг_redis",
+        "вызов_предохранителя",
     ]
 
 
@@ -54,4 +54,4 @@ async def test_should_open_breaker_after_failures() -> None:
     # third call should trip the breaker
     with pytest.raises(CircuitBreakerError):
         await repo.add_to_stream("s", {"foo": "bar"})
-    assert tracer.spans[-1].name == "circuitbreaker_call"
+    assert tracer.spans[-1].name == "вызов_предохранителя"

--- a/{{cookiecutter.project_slug}}/tests/unit/test_tasks_service.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_tasks_service.py
@@ -22,7 +22,7 @@ async def test_enqueue_task_formats_and_stores_message() -> None:
     assert json.loads(stored["payload"]) == payload
     assert "task_id" in stored
     assert "timestamp" in stored
-    assert tracer.spans and tracer.spans[0].name == "enqueue_task"
+    assert tracer.spans and tracer.spans[0].name == "постановка_задачи"
 
 
 def test_calculate_metrics() -> None:
@@ -31,7 +31,7 @@ def test_calculate_metrics() -> None:
     assert avg == 2.0
     assert mn == 1.0
     assert mx == 3.0
-    assert tracer.spans and tracer.spans[0].name == "calculate_metrics"
+    assert tracer.spans and tracer.spans[0].name == "расчет_метрик"
 
 
 def test_calculate_metrics_empty_list() -> None:
@@ -40,7 +40,7 @@ def test_calculate_metrics_empty_list() -> None:
     assert avg == 0.0
     assert mn == 0.0
     assert mx == 0.0
-    assert tracer.spans and tracer.spans[0].name == "calculate_metrics"
+    assert tracer.spans and tracer.spans[0].name == "расчет_метрик"
 
 
 @pytest.mark.asyncio
@@ -90,4 +90,4 @@ async def test_should_report_average_min_max_metrics(monkeypatch) -> None:
     assert gauges["mem.avg"] == 45.0
     assert gauges["mem.min"] == 40.0
     assert gauges["mem.max"] == 50.0
-    assert [s.name for s in tracer.spans].count("enqueue_task") == 2
+    assert [s.name for s in tracer.spans].count("постановка_задачи") == 2


### PR DESCRIPTION
## Summary
- localize span names in tracing contexts
- update unit and integration tests

## Testing
- `nox -f {{cookiecutter.project_slug}}/noxfile.py -s ci-3.12 ci-3.13` *(fails: `uv pip install` exit 2)*

------
https://chatgpt.com/codex/tasks/task_e_6878d51e7c748330ac45b674340ef07f