### PR TITLE
Fix template port placeholders

### DIFF
--- a/{{cookiecutter.project_slug}}/locustfile.py
+++ b/{{cookiecutter.project_slug}}/locustfile.py
@@ -13,7 +13,7 @@ class HelloWorldUser(HttpUser):
     wait_time: Callable[['HelloWorldUser'], Union[float, int]] = between(1, 5) # type: ignore
 
     # Type hint for host, matching Optional[str] from the User base class.
-    host: Optional[str] = "http://localhost:8000"  # Default application port
+    host: Optional[str] = "http://localhost:{{cookiecutter.app_port_host}}"  # Default application port
 
     @task
     def hello_world(self) -> None:

--- a/{{cookiecutter.project_slug}}/noxfile.py
+++ b/{{cookiecutter.project_slug}}/noxfile.py
@@ -279,7 +279,8 @@ def locust(session: Session) -> None:
             f"Файл {locust_file} не найден. Для запуска Locust необходимо создать его и определить сценарии нагрузки."
         )
         session.log(
-            "Пример команды, если locustfile.py существует: locust -f locustfile.py --host=http://localhost:8000"
+            "Пример команды, если locustfile.py существует: "
+            f"locust -f locustfile.py --host=http://localhost:{{cookiecutter.app_port_host}}"
         )
         return
 

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/core/config.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/core/config.py
@@ -176,7 +176,10 @@ class AppSettings(BaseSettings):
     app_host: str = Field(
         default="0.0.0.0", description="Host for Uvicorn"
     )  # Changed default to 0.0.0.0
-    app_port: int = Field(default=8000, description="Порт Starlette приложения")
+    app_port: int = Field(
+        default={{cookiecutter.internal_app_port}},
+        description="Порт Starlette приложения",
+    )
     app_reload: bool = Field(
         default=True, description="Enable/disable Uvicorn auto-reloading"
     )


### PR DESCRIPTION
## Summary
- ensure Uvicorn port defaults use template variable
- parameterize Locust host and documentation string in noxfile

## Testing
- `nox -s ci-3.12 ci-3.13`

------
https://chatgpt.com/codex/tasks/task_e_6878e30293448330b236f585a6a24410