### PR TITLE
Fix extraneous f-string

### DIFF
--- a/{{cookiecutter.project_slug}}/noxfile.py
+++ b/{{cookiecutter.project_slug}}/noxfile.py
@@ -280,7 +280,7 @@ def locust(session: Session) -> None:
         )
         session.log(
             "Пример команды, если locustfile.py существует: "
-            f"locust -f locustfile.py --host=http://localhost:{{cookiecutter.app_port_host}}"
+            "locust -f locustfile.py --host=http://localhost:{{cookiecutter.app_port_host}}"
         )
         return
 


### PR DESCRIPTION
## Summary
- fix linter issue in noxfile by removing unused f-string

## Testing
- `nox -s ci-3.12 ci-3.13` *(fails: no noxfile.py)*

------
https://chatgpt.com/codex/tasks/task_e_6878e99894b08330bd02ce6c46dfcdb2