### PR TITLE
Configure Locust health spammer

### DIFF
--- a/{{cookiecutter.project_slug}}/locustfile.py
+++ b/{{cookiecutter.project_slug}}/locustfile.py
@@ -1,34 +1,23 @@
-from locust import HttpUser, task, between # type: ignore
-from typing import Optional, Callable, Union # For host type hint and wait_time
+from locust import HttpUser, constant, task  # type: ignore
+from typing import Callable, Optional, Union
 
 
-class HelloWorldUser(HttpUser):
-    """
-    A simple Locust user that makes a GET request to "/".
-    """
-    # Type hint for wait_time.
-    # between(1,5) returns a callable.
-    # If Pyright has issues with 'between' types from locust stubs,
-    # type: ignore is a pragmatic way to handle it.
-    wait_time: Callable[['HelloWorldUser'], Union[float, int]] = between(1, 5) # type: ignore
+class HealthUser(HttpUser):
+    """Locust user that spams ``/health`` requests."""
 
-    # Type hint for host, matching Optional[str] from the User base class.
-    host: Optional[str] = "http://localhost:{{cookiecutter.app_port_host}}"  # Default application port
+    wait_time: Callable[["HealthUser"], Union[float, int]] = constant(0)
+    host: Optional[str] = "http://localhost:{{cookiecutter.app_port_host}}"
 
     @task
-    def hello_world(self) -> None:
-        """
-        Task that sends a GET request to the root endpoint.
-        """
-        # Example of making a request.
-        # The actual endpoint depends on what your target application serves.
-        self.client.get("/")
-        print("User requested /")
+    def health(self) -> None:
+        """Send a ``GET`` request to the ``/health`` endpoint."""
+        self.client.get("/health")
+
 
 # Example of how you might run this if it were a standalone script (not typical for locust)
 # if __name__ == "__main__":
 #    # This part is usually handled by the Locust runner
 #    # For local testing or understanding, you might instantiate and call tasks,
 #    # but it's not how Locust itself operates.
-#    user = HelloWorldUser(environment.Environment()) # Needs an Environment
-#    user.hello_world()
+#    user = HealthUser(environment.Environment())  # Needs an Environment
+#    user.health()


### PR DESCRIPTION
## Summary
- update Locust script to send repeated `/health` requests

## Testing
- `pytest -q` *(fails: invalid template syntax)*
- `nox -s ci-3.12 ci-3.13` *(fails: pyenv version `{{cookiecutter.python_version}}` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6878eb761e508330a417014fd885042e