### PR TITLE
Fix environment variable name in tests

### DIFF
--- a/{{cookiecutter.project_slug}}/tests/conftest.py
+++ b/{{cookiecutter.project_slug}}/tests/conftest.py
@@ -9,7 +9,8 @@ from httpx import AsyncClient, ASGITransport
 from starlette.routing import Router
 
 # Ensure test environment
-os.environ["APP_ENV"] = "test"
+# Pydantic settings use the ``APP_`` prefix so we need ``APP_APP_ENV``
+os.environ["APP_APP_ENV"] = "test"
 
 from {{cookiecutter.python_package_name}}.api import app as fastapi_app
 from {{cookiecutter.python_package_name}}.api import health, tasks, main as api_main


### PR DESCRIPTION
## Summary
- correct test environment variable prefix for Pydantic settings

## Testing
- `pytest -q` *(fails: invalid syntax from template placeholders)*
- `nox -s ci-3.12 ci-3.13` *(fails: noxfile.py missing)*

------
https://chatgpt.com/codex/tasks/task_e_68793274792883308dbef86c503254b4