### PR TITLE
Fix tracing context for background tasks

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/main.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/main.py
@@ -32,21 +32,22 @@ async def on_startup() -> None:
     """Log startup message."""
     with tracer.start_as_current_span("запуск"):
         log.info("Application startup")
-        await start_task_processor()
+    await start_task_processor()
 
 
 @app.on_event("shutdown")  # pyright: ignore[reportUnknownMemberType,reportUntypedFunctionDecorator]
 async def on_shutdown() -> None:
     """Clean up resources on shutdown."""
     with tracer.start_as_current_span("остановка"):
-        await _close_repo(health.redis_repo)
-        await _close_repo(tasks.tasks_service.repo)
-        await stop_task_processor()
-        await statsd_client.close()
-        statsd_client.reset()
-        tracer.spans.clear()
-        shutdown_tracer()
-        log.info("Application shutdown complete")
+        log.info("Application shutdown")
+    await _close_repo(health.redis_repo)
+    await _close_repo(tasks.tasks_service.repo)
+    await stop_task_processor()
+    await statsd_client.close()
+    statsd_client.reset()
+    tracer.spans.clear()
+    shutdown_tracer()
+    log.info("Application shutdown complete")
 
 
 async def _close_repo(repo: RedisRepository | Any) -> None:


### PR DESCRIPTION
## Summary
- avoid running task processor within startup span
- run shutdown tasks after the shutdown span completes

## Testing
- `pytest -q` *(fails: invalid syntax in tests due to unresolved cookiecutter variables)*
- `nox -f {{cookiecutter.project_slug}}/noxfile.py -s ci-3.12 ci-3.13` *(fails: invalid package metadata in pyproject.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68794a76ac8c8330ac5d8e9062f81ec9