### PR TITLE
Remove root tracing span

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/main.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/main.py
@@ -13,7 +13,6 @@ import uvicorn
 
 from {{cookiecutter.python_package_name}}.core.config import settings
 from {{cookiecutter.python_package_name}}.core.logging_config import get_logger
-from {{cookiecutter.python_package_name}}.utils.tracing import tracer
 
 log = get_logger(__name__)
 
@@ -27,10 +26,9 @@ if __name__ == "__main__":
     log.info(f"Code auto-reloading: {'Enabled' if settings.app_reload else 'Disabled'}")
     log.info("Press CTRL+C to stop the server.")
 
-    with tracer.start_as_current_span("главная"):
-        uvicorn.run(
-            "{{cookiecutter.python_package_name}}.api:app",
-            host=settings.app_host,
-            port=settings.app_port,
-            reload=settings.app_reload,
-        )
+    uvicorn.run(
+        "{{cookiecutter.python_package_name}}.api:app",
+        host=settings.app_host,
+        port=settings.app_port,
+        reload=settings.app_reload,
+    )


### PR DESCRIPTION
## Summary
- stop wrapping `uvicorn.run` with root tracer span

## Testing
- `pytest -q` *(fails: invalid syntax due to cookiecutter placeholders)*
- `nox -f {{cookiecutter.project_slug}}/noxfile.py -s ci-3.12 ci-3.13` *(fails: failed to parse metadata)*

------
https://chatgpt.com/codex/tasks/task_e_68794a76ac8c8330ac5d8e9062f81ec9