### PR TITLE
Add metrics middleware

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/main.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/api/main.py
@@ -8,15 +8,12 @@ from ..repository.redis_repo import RedisRepository
 
 from ..core.logging_config import get_logger
 from ..utils import statsd_client, tracer
+from ..middleware import MetricsMiddleware
 from ..utils.tracing import shutdown_tracer
 from . import health, tasks
 
 from .health import router as health_router
-from .tasks import (
-    router as tasks_router,
-    start_task_processor,
-    stop_task_processor,
-)
+from .tasks import router as tasks_router, start_task_processor, stop_task_processor
 
 router = Router()
 router.routes.extend(health_router.routes)
@@ -25,6 +22,7 @@ router.routes.extend(tasks_router.routes)
 log = get_logger(__name__)
 
 app = Starlette(routes=router.routes)
+app.add_middleware(MetricsMiddleware, repo=tasks.tasks_service.repo)
 
 
 @app.on_event("startup")  # pyright: ignore[reportUnknownMemberType,reportUntypedFunctionDecorator]

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/middleware/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/middleware/__init__.py
@@ -1,0 +1,5 @@
+"""Application middleware components."""
+
+from .metrics import MetricsMiddleware
+
+__all__ = ["MetricsMiddleware"]

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/middleware/metrics.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/middleware/metrics.py
@@ -1,0 +1,32 @@
+"""Middleware for collecting request metrics."""
+
+from __future__ import annotations
+
+import time
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+from starlette.requests import Request
+from starlette.responses import Response
+
+from ..repository.redis_repo import RedisRepository
+from ..utils import TASKS_STREAM_NAME, statsd_client, tracer
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Measure request duration and queue size via StatsD."""
+
+    def __init__(self, app: ASGIApp, repo: RedisRepository) -> None:
+        super().__init__(app)
+        self.repo = repo
+
+    async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[override]
+        start = time.perf_counter()
+        response = await call_next(request)
+        duration_ms = (time.perf_counter() - start) * 1000
+        await statsd_client.gauge("request_duration", duration_ms)
+        try:
+            size = await self.repo.length(TASKS_STREAM_NAME)
+            await statsd_client.gauge("task_queue_size", float(size))
+        except Exception:
+            pass
+        return response

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/repository/redis_repo.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/repository/redis_repo.py
@@ -91,5 +91,13 @@ class RedisRepository:
             )
             return cast(int, result)
 
+    async def length(self, stream_name: str) -> int:
+        """Return the length of a Redis Stream."""
+        with tracer.start_as_current_span("длина_стрима"):
+            result: Any = await self.breaker.call_async(
+                cast(Callable[..., Awaitable[Any]], self.redis.xlen), stream_name
+            )
+            return cast(int, result)
+
 
 __all__ = ["RedisRepository"]

--- a/{{cookiecutter.project_slug}}/tests/integration/test_metrics_middleware.py
+++ b/{{cookiecutter.project_slug}}/tests/integration/test_metrics_middleware.py
@@ -1,0 +1,30 @@
+import asyncio
+import pytest
+from httpx import AsyncClient
+from starlette import status
+
+from {{cookiecutter.python_package_name}}.utils import (
+    TASKS_ENDPOINT_PATH,
+    TASKS_STREAM_NAME,
+    statsd_client,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_should_collect_duration_and_queue_size(
+    async_client: AsyncClient, fake_redis
+) -> None:
+    statsd_client.reset()
+    fake_redis.streams.clear()
+
+    response = await async_client.post(
+        TASKS_ENDPOINT_PATH, json={"data": "x", "metadata": {}}
+    )
+    await asyncio.sleep(0)
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    assert statsd_client.gauges["request_duration"] > 0
+    assert statsd_client.gauges["task_queue_size"] == len(
+        fake_redis.streams[TASKS_STREAM_NAME]
+    )


### PR DESCRIPTION
## Summary
- implement `MetricsMiddleware` to track request duration and queue size
- support stream length in `RedisRepository`
- wire middleware into application
- adapt tests to configure middleware
- add integration test for middleware metrics

## Testing
- `pytest -q` *(fails: SyntaxError due to template placeholders)*
- `nox -s ci-3.12 ci-3.13` *(fails: pyenv couldn't find the template Python version)*

------
https://chatgpt.com/codex/tasks/task_e_687957395c148330bce4d54794567931