### PR TITLE
Add retry and DLQ handling

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/redis_stream.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/redis_stream.py
@@ -31,7 +31,13 @@ class RedisStream:
 
 
 TASKS_STREAM_NAME = settings.redis.stream_name
+DEAD_LETTER_STREAM_NAME = f"{settings.redis.stream_name}:dlq"
 
 redis_stream = RedisStream(settings.redis.url)
 
-__all__ = ["TASKS_STREAM_NAME", "RedisStream", "redis_stream"]
+__all__ = [
+    "TASKS_STREAM_NAME",
+    "DEAD_LETTER_STREAM_NAME",
+    "RedisStream",
+    "redis_stream",
+]


### PR DESCRIPTION
## Summary
- implement exponential backoff with 3 attempts in `TasksService`
- send failed messages to dead-letter stream
- expose dead-letter stream constant
- test retry logic and DLQ usage

## Testing
- `python3.12 -m pytest -q` *(fails: SyntaxError due to template variables)*
- `nox -s ci-3.12 ci-3.13` *(fails: TOML parse error in pyproject)*

------
https://chatgpt.com/codex/tasks/task_e_68795708c35c83308423136a39651327