### PR TITLE
Fix utils exports and lint issues

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/middleware/metrics.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/middleware/metrics.py
@@ -9,7 +9,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from ..repository.redis_repo import RedisRepository
-from ..utils import TASKS_STREAM_NAME, statsd_client, tracer
+from ..utils import TASKS_STREAM_NAME, statsd_client
 
 
 class MetricsMiddleware(BaseHTTPMiddleware):

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/__init__.py
@@ -2,16 +2,22 @@
 
 from ..core.config import settings
 from .metrics import statsd_client
-from .redis_stream import RedisStream, TASKS_STREAM_NAME, redis_stream
+from .redis_stream import (
+    DEAD_LETTER_STREAM_NAME,
+    RedisStream,
+    TASKS_STREAM_NAME,
+    redis_stream,
+)
 from .tracing import tracer
 from .circuitbreaker import CircuitBreaker, CircuitBreakerError
 
 __all__ = [
-    "TASKS_ENDPOINT_PATH",
-    "TASKS_STREAM_NAME",
     "CircuitBreaker",
     "CircuitBreakerError",
+    "DEAD_LETTER_STREAM_NAME",
     "RedisStream",
+    "TASKS_ENDPOINT_PATH",
+    "TASKS_STREAM_NAME",
     "redis_stream",
     "statsd_client",
     "tracer",

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/redis_stream.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/redis_stream.py
@@ -36,8 +36,8 @@ DEAD_LETTER_STREAM_NAME = f"{settings.redis.stream_name}:dlq"
 redis_stream = RedisStream(settings.redis.url)
 
 __all__ = [
-    "TASKS_STREAM_NAME",
     "DEAD_LETTER_STREAM_NAME",
     "RedisStream",
+    "TASKS_STREAM_NAME",
     "redis_stream",
 ]


### PR DESCRIPTION
## Summary
- remove unused `tracer` import from metrics middleware
- export `DEAD_LETTER_STREAM_NAME` from utils package
- keep `__all__` lists sorted

## Testing
- `ruff format {{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/middleware/metrics.py {{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/__init__.py {{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/utils/redis_stream.py`
- `ruff check {{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}` *(fails: Invalid module name due to template placeholders)*
- `nox -s ci-3.12` *(fails: Python {{cookiecutter.python_version}} not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68795a4783e883308cf68599cddb37c3