### PR TITLE
Fix tests for new starlette

### DIFF
--- a/{{cookiecutter.project_slug}}/tests/conftest.py
+++ b/{{cookiecutter.project_slug}}/tests/conftest.py
@@ -103,7 +103,10 @@ async def fake_redis(monkeypatch) -> AsyncGenerator[FakeRedis, None]:
     fastapi_app.router.routes = list(api_main.router.routes)
     for mw in fastapi_app.user_middleware:
         if mw.cls is MetricsMiddleware:
-            mw.options["repo"] = fake
+            if hasattr(mw, "options"):
+                mw.options["repo"] = fake
+            else:
+                mw.kwargs["repo"] = fake
     fastapi_app.middleware_stack = fastapi_app.build_middleware_stack()
     yield fake
 


### PR DESCRIPTION
## Summary
- adjust test fixtures for Starlette >=0.36

## Testing
- `nox -s ci-3.12 ci-3.13` *(fails: config files not trusted)*

------
https://chatgpt.com/codex/tasks/task_e_68795d42fa6c8330ac5eec87f433597f