### PR TITLE
Fix metrics gauge and retry tests

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/tasks_service.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/tasks_service.py
@@ -89,6 +89,8 @@ class TasksService:
                     await self._record_usage()
                     return result
 
+            return ""
+
 
     async def _record_usage(self) -> None:
         """Record CPU, memory and GPU usage to StatsD."""

--- a/{{cookiecutter.project_slug}}/tests/conftest.py
+++ b/{{cookiecutter.project_slug}}/tests/conftest.py
@@ -90,6 +90,10 @@ class FakeRedis:
     async def xlen(self, stream_name: str) -> int:
         return len(self.streams[stream_name])
 
+    async def length(self, stream_name: str) -> int:
+        """Return current length of the specified stream."""
+        return await self.xlen(stream_name)
+
 
 @pytest_asyncio.fixture(autouse=True)
 async def fake_redis(monkeypatch) -> AsyncGenerator[FakeRedis, None]:

--- a/{{cookiecutter.project_slug}}/tests/unit/test_tasks_service.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_tasks_service.py
@@ -140,9 +140,13 @@ async def test_should_send_to_dead_letter_after_retries(monkeypatch) -> None:
     repo = FailingRepo(fail_times=3)
     service = TasksService(repo)  # type: ignore[arg-type]
 
+    async def fast_sleep(*_: float) -> None:
+        """Async sleep stub used to skip real waiting."""
+        return None
+
     monkeypatch.setattr(
         "{{cookiecutter.python_package_name}}.services.tasks_service.asyncio.sleep",
-        lambda *_: None,
+        fast_sleep,
     )
 
     await service.enqueue_task({"data": 2})


### PR DESCRIPTION
## Summary
- ensure task service always returns a string
- expose `length` method in `FakeRedis`
- use async stub for sleep in retry test

## Testing
- `nox -s ci-3.12 ci-3.13` *(fails: Failed to parse metadata from built wheel)*
- `pytest -q` *(fails: invalid syntax in template placeholders)*

------
https://chatgpt.com/codex/tasks/task_e_68795f8fcaa083309ca6a793a804e1c7