### PR TITLE
Implement concurrent task processing

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/task_processor.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/task_processor.py
@@ -6,9 +6,11 @@ import asyncio
 import json
 from typing import Any, Dict
 
+from ..core.config import settings
+from ..utils import DEAD_LETTER_STREAM_NAME, TASKS_STREAM_NAME, tracer
+
 from ..repository.redis_repo import RedisRepository
 from ..core.logging_config import get_logger
-from ..utils import TASKS_STREAM_NAME, tracer
 
 log = get_logger(__name__)
 
@@ -20,6 +22,8 @@ class TaskProcessor:
         self.repo = repo
         self._running = False
         self._task: asyncio.Task[None] | None = None
+        self._background_tasks: set[asyncio.Task[Any]] = set()
+        self._semaphore = asyncio.Semaphore(settings.performance.max_concurrent_tasks)
 
     async def start(self) -> None:
         """Start processing tasks in the background."""
@@ -34,8 +38,9 @@ class TaskProcessor:
                 await asyncio.sleep(0.1)
                 continue
             msg_id, fields = msgs[0]
-            await self.handle(fields)
-            await self.repo.ack(TASKS_STREAM_NAME, msg_id)
+            task = asyncio.create_task(self._process(msg_id, fields))
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
 
     async def handle(self, fields: Dict[str, Any]) -> None:
         """Placeholder task handler."""
@@ -44,8 +49,34 @@ class TaskProcessor:
             log.info("Handled task %s", payload)
             await asyncio.sleep(0)
 
+    async def _process(self, msg_id: str, fields: Dict[str, Any]) -> None:
+        async with self._semaphore:
+            attempts = 0
+            while attempts < 3:
+                try:
+                    await self.handle(fields)
+                except Exception as exc:  # pragma: no cover - handler failures
+                    attempts += 1
+                    log.error(
+                        "Task handling failed (attempt %s)", attempts, exc_info=exc
+                    )
+                    if attempts >= 3:
+                        try:
+                            await self.repo.add_to_stream(DEAD_LETTER_STREAM_NAME, fields)
+                        except Exception as dead_exc:  # pragma: no cover - network errors
+                            log.error(
+                                "Failed to enqueue to dead-letter", exc_info=dead_exc
+                            )
+                        break
+                    await asyncio.sleep(2 ** (attempts - 1))
+                else:
+                    break
+            await self.repo.ack(TASKS_STREAM_NAME, msg_id)
+
     async def stop(self) -> None:
         """Stop background processing."""
         self._running = False
         if self._task is not None:
             await self._task
+        if self._background_tasks:
+            await asyncio.gather(*self._background_tasks, return_exceptions=True)

--- a/{{cookiecutter.project_slug}}/tests/unit/test_task_processor.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_task_processor.py
@@ -5,7 +5,11 @@ import pytest
 
 from {{cookiecutter.python_package_name}}.repository.redis_repo import RedisRepository
 from {{cookiecutter.python_package_name}}.services.task_processor import TaskProcessor
-from {{cookiecutter.python_package_name}}.utils import TASKS_STREAM_NAME, tracer
+from {{cookiecutter.python_package_name}}.utils import (
+    TASKS_STREAM_NAME,
+    DEAD_LETTER_STREAM_NAME,
+    tracer,
+)
 from tests.conftest import FakeRedis
 
 
@@ -31,3 +35,36 @@ async def test_task_processor_handles_message() -> None:
 
     assert handled == [{"v": 1}]
     assert any(span.name == "обработка_задачи" for span in tracer.spans)
+
+
+@pytest.mark.asyncio
+async def test_task_processor_retries_and_dead_letter(monkeypatch) -> None:
+    fake = FakeRedis()
+    repo = RedisRepository(client=fake)
+    await repo.add_to_stream(TASKS_STREAM_NAME, {"payload": json.dumps({"v": 2})})
+
+    processor = TaskProcessor(repo)
+
+    attempts: int = 0
+
+    async def failing_handle(_: dict) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("boom")
+
+    async def fast_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "{{cookiecutter.python_package_name}}.services.task_processor.asyncio.sleep",
+        fast_sleep,
+    )
+
+    processor.handle = failing_handle  # type: ignore[assignment]
+
+    await processor.start()
+    await asyncio.sleep(0)  # allow processing
+    await processor.stop()
+
+    assert attempts == 3
+    assert fake.streams[DEAD_LETTER_STREAM_NAME]


### PR DESCRIPTION
## Summary
- process tasks concurrently using a semaphore
- implement retries with exponential backoff and dead letter support
- test retry behaviour

## Testing
- `nox -s ci-3.12 ci-3.13` *(fails: failed to parse metadata from built wheel)*

------
https://chatgpt.com/codex/tasks/task_e_687a0c7ea0e083308f79d189d1862788