### PR TITLE
Fix task processor start

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/task_processor.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/services/task_processor.py
@@ -30,6 +30,8 @@ class TaskProcessor:
         self._running = True
         await self.repo.create_group(TASKS_STREAM_NAME)
         self._task = asyncio.create_task(self._run())
+        # allow the processing loop to start before returning
+        await asyncio.sleep(0)
 
     async def _run(self) -> None:
         while self._running:
@@ -62,8 +64,12 @@ class TaskProcessor:
                     )
                     if attempts >= 3:
                         try:
-                            await self.repo.add_to_stream(DEAD_LETTER_STREAM_NAME, fields)
-                        except Exception as dead_exc:  # pragma: no cover - network errors
+                            await self.repo.add_to_stream(
+                                DEAD_LETTER_STREAM_NAME, fields
+                            )
+                        except (
+                            Exception
+                        ) as dead_exc:  # pragma: no cover - network errors
                             log.error(
                                 "Failed to enqueue to dead-letter", exc_info=dead_exc
                             )


### PR DESCRIPTION
## Summary
- ensure the task processor loop has a chance to start before returning from `start`

## Testing
- `pipx run --spec nox nox -s ci-3.12 ci-3.13` *(fails: uv failed to parse metadata due to template placeholders)*

------
https://chatgpt.com/codex/tasks/task_e_687a111db8ec83308eaf34bf4941707f