### PR TITLE
Fix Redis group creation

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/repository/redis_repo.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/repository/redis_repo.py
@@ -54,7 +54,7 @@ class RedisRepository:
                     cast(Callable[..., Awaitable[Any]], self.redis.xgroup_create),
                     stream_name,
                     settings.redis.consumer_group,
-                    id="$",
+                    id="0",
                     mkstream=True,
                 )
             except ResponseError as exc:


### PR DESCRIPTION
## Summary
- set consumer group creation ID to `0` so queued tasks are processed

## Testing
- `nox -s ci-3.12 ci-3.13` *(fails: `command not found: nox`)*
- `pytest -q` *(fails: `pyenv: version '{{cookiecutter.python_version}}' is not installed`)*

------
https://chatgpt.com/codex/tasks/task_e_687a111db8ec83308eaf34bf4941707f