### PR TITLE
Fix test wait loop

### DIFF
--- a/{{cookiecutter.project_slug}}/tests/unit/test_task_processor.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_task_processor.py
@@ -53,7 +53,8 @@ async def test_task_processor_retries_and_dead_letter(monkeypatch) -> None:
         raise RuntimeError("boom")
 
     async def fast_sleep(_: float) -> None:
-        return None
+        """Async sleep stub used to yield without delay."""
+        await asyncio.sleep(0)
 
     monkeypatch.setattr(
         "{{cookiecutter.python_package_name}}.services.task_processor.asyncio.sleep",


### PR DESCRIPTION
## Summary
- ensure patched sleep yields control in task processor test

## Testing
- `nox -s ci-3.12 ci-3.13` *(fails: Failed to parse metadata from built wheel)*

------
https://chatgpt.com/codex/tasks/task_e_687a5357fe4483309e4feda2b1abb063