### PR TITLE
Fix test recursion

### DIFF
--- a/{{cookiecutter.project_slug}}/tests/unit/test_task_processor.py
+++ b/{{cookiecutter.project_slug}}/tests/unit/test_task_processor.py
@@ -52,12 +52,14 @@ async def test_task_processor_retries_and_dead_letter(monkeypatch) -> None:
         attempts += 1
         raise RuntimeError("boom")
 
+    original_sleep = asyncio.sleep
+
     async def fast_sleep(_: float) -> None:
         """Async sleep stub used to yield without delay."""
-        await asyncio.sleep(0)
+        await original_sleep(0)
 
     monkeypatch.setattr(
-        "{{cookiecutter.python_package_name}}.services.task_processor.asyncio.sleep",
+        "{{cookiecutter.python_package_name}}.services.task_processor._yield_sleep",
         fast_sleep,
     )
 


### PR DESCRIPTION
## Summary
- fix async sleep monkeypatch in tests to avoid recursion

## Testing
- `PYENV_VERSION=3.13.3 nox -s ci-3.12 ci-3.13` *(fails: TOML parse error due to cookiecutter placeholders)*

------
https://chatgpt.com/codex/tasks/task_e_687a649ee32483309ca04e7444afe70b