### PR TITLE
Remove reading trace from repository fetch

### DIFF
--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/repository/redis_repo.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.python_package_name}}/repository/redis_repo.py
@@ -65,20 +65,19 @@ class RedisRepository:
         self, stream_name: str, count: int = 1, block_ms: int = 1000
     ) -> List[Tuple[str, Dict[str, Any]]]:
         """Read messages from a stream using XREADGROUP."""
-        with tracer.start_as_current_span("чтение_из_группы"):
-            result: Any = await self.breaker.call_async(
-                cast(Callable[..., Awaitable[Any]], self.redis.xreadgroup),
-                settings.redis.consumer_group,
-                settings.redis.consumer_name,
-                streams={stream_name: ">"},
-                count=count,
-                block=block_ms,
-            )
-            messages: List[Tuple[str, Dict[str, Any]]] = []
-            for _stream, msgs in result or []:
-                for msg_id, data in msgs:
-                    messages.append((cast(str, msg_id), cast(Dict[str, Any], data)))
-            return messages
+        result: Any = await self.breaker.call_async(
+            cast(Callable[..., Awaitable[Any]], self.redis.xreadgroup),
+            settings.redis.consumer_group,
+            settings.redis.consumer_name,
+            streams={stream_name: ">"},
+            count=count,
+            block=block_ms,
+        )
+        messages: List[Tuple[str, Dict[str, Any]]] = []
+        for _stream, msgs in result or []:
+            for msg_id, data in msgs:
+                messages.append((cast(str, msg_id), cast(Dict[str, Any], data)))
+        return messages
 
     async def ack(self, stream_name: str, message_id: str) -> int:
         """Acknowledge message processing."""


### PR DESCRIPTION
## Summary
- stop tracing `fetch` method read operations

## Testing
- `pytest -q` *(fails: SyntaxError in tests)*
- `nox -f {{cookiecutter.project_slug}}/noxfile.py -s ci-3.12 -s ci-3.13` *(fails to install deps due to template placeholders)*

------
https://chatgpt.com/codex/tasks/task_e_687a6aae87cc8330a69bd0d4d4da7dbf