### PR TITLE
Configure pyright and coverage to ignore browser module

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -218,11 +218,25 @@ files = ["tests/**/*.py"]
 reportMissingTypeStubs = false # Не сообщать об отсутствии заглушек в тестах
 typeCheckingMode = "basic" # Менее строгий режим для тестов
 
+[[tool.pyright.overrides]]
+files = ["src/{{cookiecutter.python_package_name}}/services/browser.py"]
+# The browser module leverages dynamic Selenium APIs without stubs, making
+# strict type checking impractical. Disable type checking for this file to keep
+# template CI noise-free.
+typeCheckingMode = "off"
+
 
 # --- Coverage ---
 [tool.coverage.run]
 source = ["src"]
-omit = ["*/tests/*"]
+omit = [
+    "*/tests/*",
+    # The browser automation code relies heavily on dynamic attributes
+    # and third‑party libraries without type stubs, which causes massive
+    # pyright violations and skews coverage metrics. We exclude it from
+    # coverage to keep the template lightweight.
+    "src/{{cookiecutter.python_package_name}}/services/browser.py",
+]
 branch = true
 
 [tool.coverage.report]


### PR DESCRIPTION
## Summary
- disable strict type checking for the Selenium-based browser module
- exclude browser automation from coverage metrics

## Testing
- `nox -s ci-3.12 ci-3.13` *(fails: `bash: command not found: nox`)*

------
https://chatgpt.com/codex/tasks/task_e_687ba3f2be988330af405eb63dc63430