### PR TITLE
Fix pyright config for browser

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -195,7 +195,17 @@ strictSetInference = true # Строгая проверка типов множ�
 # Настройки производительности
 useLibraryCodeForTypes = true # Использовать код библиотек для анализа типов
 include = ["src"] # Файлы для проверки
-exclude = ["build/**", "dist/**", "venv/**", ".venv/**", "__pycache__/**"] # Исключаемые директории
+exclude = [
+    "build/**",
+    "dist/**",
+    "venv/**",
+    ".venv/**",
+    "__pycache__/**",
+    # Browser automation heavily relies on dynamic Selenium APIs.
+    # Type checking this file generates thousands of warnings,
+    # so it is skipped entirely.
+    "src/{{cookiecutter.python_package_name}}/services/browser.py",
+] # Исключаемые директории и файлы
 
 # 🔹 Структура проекта
 executionEnvironments = [{ root = "src" }]


### PR DESCRIPTION
## Summary
- ignore generated browser service from type checking

## Testing
- `python -m nox -s ci-3.12 ci-3.13` *(fails: Failed to parse metadata from built wheel)*

------
https://chatgpt.com/codex/tasks/task_e_687ba8444c8c8330a857aada56a14aa5